### PR TITLE
Multi exit blocks

### DIFF
--- a/parsers/creation/flowparser.py
+++ b/parsers/creation/flowparser.py
@@ -386,6 +386,12 @@ class FlowParser:
         if not row.include_if:
             return
 
+        if row.type in ['hard_exit', 'loose_exit']:
+            destination_uuid = 'HARD_EXIT' if row.type == 'hard_exit' else None
+            for edge in row.edges:
+                self._add_row_edge(edge, destination_uuid)
+            return
+
         if row.type == 'go_to':
             self._parse_goto_row(row)
             return

--- a/parsers/creation/flowparser.py
+++ b/parsers/creation/flowparser.py
@@ -15,10 +15,14 @@ from .flowrowmodel import Condition
 
 
 class NodeGroup:
+    # NodeGroups may have multiple exit nodes.
+    # add_exit connects ALL of them, except for those
+    # which are marked as hard exits
+    # (which are not tracked as loose_exits)
+
     def __init__(self):
         # node_groups may contain NodeGroups and RowNodeGroups
         self.node_groups = []
-        self.loose_exits = []
 
     def is_empty(self):
         return self.node_groups == []
@@ -29,8 +33,24 @@ class NodeGroup:
     def last_node_group(self):
         return self.node_groups[-1]
 
+    def has_loose_exits(self):
+        for node_group in self.node_groups:
+            if node_group.has_loose_exits():
+                return True
+        return False
+
     def add_exit(self, destination_uuid, condition):
-        self.last_node_group().add_exit(destination_uuid, condition)
+        if condition != Condition():
+            raise ValueError('Cannot attach conditional edges to a block.')
+        if not self.has_loose_exits():
+            raise ValueError('Block has no loose exit to connect to.')
+        for node_group in self.node_groups:
+            if node_group.has_loose_exits():
+                node_group.connect_loose_exits(destination_uuid)
+
+    def connect_loose_exits(self, destination_uuid):
+        for node_group in self.node_groups:
+            node_group.connect_loose_exits(destination_uuid)
 
     def add_node_group(self, node_group):
         # Node: Connecting of exits is not done here.
@@ -43,6 +63,8 @@ class NodeGroup:
 
 class RowNodeGroup:
     # Group of nodes representing a row in the sheet.
+    # RowNodeGroups have a single exit node
+    # (which may have multiple conditional exits)
 
     def __init__(self, node, row_type):
         '''node: first node in the group'''
@@ -60,6 +82,20 @@ class RowNodeGroup:
         for node in self.nodes:
             flow_container.add_node(node)
 
+    def has_loose_exits(self):
+        # A loose exit is a default exit (i.e. exit of a router-less node,
+        # or exit connected to the default router case) which is not
+        # connected to any further node.
+        for exit in self.nodes[-1].get_exits():
+            if exit.destination_uuid is None:
+                return True
+        return False
+
+    def connect_loose_exits(self, destination_uuid):
+        for exit in self.nodes[-1].get_exits():
+            if exit.destination_uuid is None:
+                exit.destination_uuid = destination_uuid
+
     def add_exit(self, destination_uuid, condition):
         exit_node = self.nodes[-1]
         # Unconditional/default case edge
@@ -74,6 +110,7 @@ class RowNodeGroup:
         if isinstance(exit_node, EnterFlowNode):
             if condition.value.lower() in ['complete', 'completed']:
                 exit_node.update_completed_exit(destination_uuid)
+                self.has_loose_exit = False
             elif condition.value.lower() == 'expired':
                 exit_node.update_expired_exit(destination_uuid)
             else:

--- a/parsers/creation/flowrowmodel.py
+++ b/parsers/creation/flowrowmodel.py
@@ -115,6 +115,8 @@ class FlowRowModel(ParserModel):
             "end_for" : "mainarg_none",
             "begin_block" : "mainarg_none",
             "end_block" : "mainarg_none",
+            "hard_exit" : "mainarg_none",
+            "loose_exit" : "mainarg_none",
         }
 
         if header in basic_header_dict:

--- a/parsers/creation/tests/test_flowparser.py
+++ b/parsers/creation/tests/test_flowparser.py
@@ -589,6 +589,26 @@ class TestMultiExitBlocks(TestBlocks):
         messages_exp = ['Following text']
         self.run_example(table_data, messages_exp, Context(variables={'@my_field' : 'Other'}))
 
+    def test_split_by_value_hard_loose_exit(self):
+        table_data = (
+            'row_id,type,from,condition,message_text\n'
+            'X,begin_block,,,\n'
+            '1,split_by_value,,,@my_field\n'
+            ',send_message,1,Value,It has the value\n'
+            ',hard_exit,1,Value2,\n'
+            ',loose_exit,1,Value3,\n'
+            ',end_block,,,\n'
+            ',send_message,X,,Following text\n'
+        )
+        messages_exp = ['It has the value','Following text']
+        self.run_example(table_data, messages_exp, Context(variables={'@my_field' : 'Value'}))
+        messages_exp = []
+        self.run_example(table_data, messages_exp, Context(variables={'@my_field' : 'Value2'}))
+        messages_exp = ['Following text']
+        self.run_example(table_data, messages_exp, Context(variables={'@my_field' : 'Value3'}))
+        messages_exp = ['Following text']
+        self.run_example(table_data, messages_exp, Context(variables={'@my_field' : 'Other'}))
+
     def test_wait_for_response(self):
         table_data = (
             'row_id,type,from,condition,message_text,no_response\n'
@@ -605,6 +625,25 @@ class TestMultiExitBlocks(TestBlocks):
         messages_exp = ['No Response','Following text']
         self.run_example(table_data, messages_exp, Context(inputs=[None]))
         messages_exp = ['Other']
+        self.run_example(table_data, messages_exp, Context(inputs=['Something else']))
+
+    def test_wait_for_response_hard_exits(self):
+        table_data = (
+            'row_id,type,from,condition,message_text,no_response\n'
+            'X,begin_block,,,,\n'
+            '1,wait_for_response,,,,60\n'
+            ',send_message,1,Value,It has the value,\n'
+            ',hard_exit,,,,\n'
+            ',send_message,1,No Response,No Response,\n'
+            ',hard_exit,,,,\n'
+            ',end_block,,,\n'
+            ',send_message,X,,Following text,\n'
+        )
+        messages_exp = ['It has the value']
+        self.run_example(table_data, messages_exp, Context(inputs=['Value']))
+        messages_exp = ['No Response']
+        self.run_example(table_data, messages_exp, Context(inputs=[None]))
+        messages_exp = ['Following text']
         self.run_example(table_data, messages_exp, Context(inputs=['Something else']))
 
     def test_enter_flow(self):

--- a/rapidpro/models/common.py
+++ b/rapidpro/models/common.py
@@ -9,8 +9,21 @@ class Exit:
     def from_dict(data):
         return Exit(**data)
 
+    def is_hard_exit(self):
+        # This is a notion introduced in the context of blocks,
+        # which are groups of nodes included in a flow.
+        # By default, when attaching nodes to the end of a block, all
+        # unconnected exits from the block are connected, however,
+        # hard exits are omitted and exit the flow.
+        if self.destination_uuid == 'HARD_EXIT':
+            return True
+        return False
+
     def render(self):
+        destination_uuid = self.destination_uuid
+        if self.destination_uuid == 'HARD_EXIT':
+            destination_uuid = None
         return {
-            'destination_uuid': self.destination_uuid,
+            'destination_uuid': destination_uuid,
             'uuid': self.uuid,
         }


### PR DESCRIPTION
Blocks can now have multiple exits. When a node is attached to a block, all exits will be connected to that node, except for those exits explicitly marked with `hard_exit`. Exits are loose by default, so the `loose_exit` row type is not very useful except for adding cases to a switch router without attaching a node to it.