### PR TITLE
FlowParser: No_op row type

### DIFF
--- a/parsers/creation/flowrowmodel.py
+++ b/parsers/creation/flowrowmodel.py
@@ -120,6 +120,7 @@ class FlowRowModel(ParserModel):
             "end_block" : "mainarg_none",
             "hard_exit" : "mainarg_none",
             "loose_exit" : "mainarg_none",
+            "no_op" : "mainarg_none",
         }
 
         if header in basic_header_dict:

--- a/parsers/creation/flowrowmodel.py
+++ b/parsers/creation/flowrowmodel.py
@@ -128,3 +128,8 @@ class FlowRowModel(ParserModel):
         if header == "message_text":
             return row_type_to_main_arg[row["type"]]
         return header
+
+    def is_starting_row(self):
+        if len(self.edges) == 1 and self.edges[0].from_ == 'start':
+            return True
+        return False

--- a/parsers/creation/tests/test_flowparser.py
+++ b/parsers/creation/tests/test_flowparser.py
@@ -801,3 +801,19 @@ class TestNoOpRow(TestBlocks):
         self.run_example(table_data, messages_exp, context=Context(variables={'@field':"B"}))
         messages_exp = ['Start message','End Message']
         self.run_example(table_data, messages_exp, context=Context(variables={'@field':"something"}))
+
+    def test_multientry_block(self):
+        table_data = (
+            'row_id,type,from,condition,message_text\n'
+            '1,wait_for_response,start,,\n'
+            '2,send_message,1,A,Message A\n'
+            '3,send_message,1,,Other\n'
+            'X,begin_block,2;3,,\n'
+            ',send_message,,,Some text 1\n'
+            ',end_block,,,\n'
+            ',send_message,,,Following text\n'
+        )
+        messages_exp = ['Message A','Some text 1','Following text']
+        self.run_example(table_data, messages_exp, context=Context(inputs=["A"]))
+        messages_exp = ['Other','Some text 1','Following text']
+        self.run_example(table_data, messages_exp, context=Context(inputs=["something"]))


### PR DESCRIPTION
Introduces a no_op row type, which behaves like a node, but doesn't do anything.
This is useful for leading edges into a single point without requiring to do an action.

Blocks now use this implicitly to allow a block to have multiple from-rows.