### PR TITLE
FlowParser: Allow referencing extra data sheets for template instantiation

### DIFF
--- a/parsers/creation/contentindexparser.py
+++ b/parsers/creation/contentindexparser.py
@@ -61,12 +61,11 @@ class ContentIndexParser:
 	def get_template_table(self, name):
 		return self.template_sheets[name]
 
-	def get_node_group(self, template_name, data_sheet, data_row_id):
+	def get_node_group(self, template_name, data_sheet, data_row_id, extra_data_sheets):
 		# TODO: Factor out logic duplication between this function and parse_all_flows.
 		if (data_sheet and data_row_id) or (not data_sheet and not data_row_id):
 			flow_name = template_name  # = row.new_name or row.sheet_name
-			context = {}
-			return self.parse_flow(template_name, data_sheet, data_row_id, RapidProContainer(), parse_as_block=True)
+			return self.parse_flow(template_name, data_sheet, data_row_id, extra_data_sheets, RapidProContainer(), parse_as_block=True)
 		else:
 			raise ValueError(f'For insert_as_block, either both data_sheet and data_row_id or neither have to be provided.')		
 
@@ -77,14 +76,14 @@ class ContentIndexParser:
 			if row.data_sheet and not row.data_row_id:
 				data_rows = self.get_all_data_model_instances(row.data_sheet)
 				for data_row_id in data_rows.keys():
-					self.parse_flow(row.sheet_name, row.data_sheet, data_row_id, rapidpro_container)
+					self.parse_flow(row.sheet_name, row.data_sheet, data_row_id, [], rapidpro_container)
 			elif not row.data_sheet and row.data_row_id:
 				raise ValueError(f'For create_flow, if data_row_id is provided, data_sheet must also be provided.')
 			else:
-				self.parse_flow(row.sheet_name, row.data_sheet, row.data_row_id, rapidpro_container)
+				self.parse_flow(row.sheet_name, row.data_sheet, row.data_row_id, [], rapidpro_container)
 		return rapidpro_container	
 
-	def parse_flow(self, sheet_name, data_sheet, data_row_id, rapidpro_container, parse_as_block=False):
+	def parse_flow(self, sheet_name, data_sheet, data_row_id, extra_data_sheets, rapidpro_container, parse_as_block=False):
 			if data_sheet and data_row_id:
 				flow_name = ' - '.join([sheet_name, data_row_id])
 				context = self.get_data_model_instance(data_sheet, data_row_id)
@@ -92,7 +91,13 @@ class ContentIndexParser:
 				assert not data_sheet and not data_row_id
 				flow_name = sheet_name
 				context = {}
-			flow_parser = FlowParser(rapidpro_container, flow_name, self.get_template_table(sheet_name), context=dict(context), content_index_parser=self)
+			context = dict(context)
+			context["_data"] = {}
+			for extra_data_sheet in extra_data_sheets:
+				# TODO: Warning if extra_data_sheet is already in context.
+				# This means we have a variable name clash.
+				context["_data"][extra_data_sheet] = self.data_sheets[extra_data_sheet]
+			flow_parser = FlowParser(rapidpro_container, flow_name, self.get_template_table(sheet_name), context=context, content_index_parser=self)
 			if parse_as_block:
 				return flow_parser.parse_as_block()
 			else:

--- a/parsers/creation/contentindexparser.py
+++ b/parsers/creation/contentindexparser.py
@@ -28,29 +28,41 @@ class ContentIndexParser:
 			if row.status == 'draft':
 				continue
 			if row.type == 'content_index':
-				sheet = self.sheet_reader.get_sheet(row.sheet_name)
+				assert len(row.sheet_name) == 1
+				sheet_name = row.sheet_name[0]
+				sheet = self.sheet_reader.get_sheet(sheet_name)
 				self.process_content_index_table(sheet)
 			elif row.type == 'data_sheet':
-				self.process_data_sheet(row.sheet_name, row.data_model)
+				assert len(row.sheet_name) >= 1
+				self.process_data_sheet(row.sheet_name, row.new_name, row.data_model)
 			elif row.type in ['template_definition', 'create_flow']:
-				if row.sheet_name not in self.template_sheets:
-					sheet = self.sheet_reader.get_sheet(row.sheet_name)
-					self.template_sheets[row.sheet_name] = sheet
+				assert len(row.sheet_name) == 1
+				sheet_name = row.sheet_name[0]
+				if sheet_name not in self.template_sheets:
+					sheet = self.sheet_reader.get_sheet(sheet_name)
+					self.template_sheets[sheet_name] = sheet
 				if row.type == 'create_flow':
 					self.flow_definition_rows.append(row)
 			else:
 				raise ValueError(f'ContentIndex has row with invalid type: {row.type}.')
 
-	def process_data_sheet(self, sheet_name, data_model_name):
+	def process_data_sheet(self, sheet_names, new_name, data_model_name):
 		if not hasattr(self, 'user_models_module'):
 			raise ValueError("If there are data sheets, a user_data_model_module_name has to be provided")
-		data_table = self.sheet_reader.get_sheet(sheet_name)
-		user_model = getattr(self.user_models_module, data_model_name)
-		row_parser = RowParser(user_model, CellParser())
-		sheet_parser = SheetParser(row_parser, data_table)
-		data_rows = sheet_parser.parse_all()
-		content = OrderedDict((row.ID, row) for row in data_rows)
-		self.data_sheets[sheet_name] = content
+		if len(sheet_names) > 1 and not new_name:
+			raise ValueError("If multiple sheet are concatenated, a new_name has to be provided")
+		if not new_name:
+			new_name = sheet_names[0]
+		content = OrderedDict()
+		for sheet_name in sheet_names:
+			data_table = self.sheet_reader.get_sheet(sheet_name)
+			user_model = getattr(self.user_models_module, data_model_name)
+			row_parser = RowParser(user_model, CellParser())
+			sheet_parser = SheetParser(row_parser, data_table)
+			data_rows = sheet_parser.parse_all()
+			sheet_content = OrderedDict((row.ID, row) for row in data_rows)
+			content.update(sheet_content)
+		self.data_sheets[new_name] = content
 
 	def get_data_model_instance(self, sheet_name, row_id):
 		return self.data_sheets[sheet_name][row_id]
@@ -76,11 +88,11 @@ class ContentIndexParser:
 			if row.data_sheet and not row.data_row_id:
 				data_rows = self.get_all_data_model_instances(row.data_sheet)
 				for data_row_id in data_rows.keys():
-					self.parse_flow(row.sheet_name, row.data_sheet, data_row_id, row.extra_data_sheets, rapidpro_container)
+					self.parse_flow(row.sheet_name[0], row.data_sheet, data_row_id, row.extra_data_sheets, rapidpro_container)
 			elif not row.data_sheet and row.data_row_id:
 				raise ValueError(f'For create_flow, if data_row_id is provided, data_sheet must also be provided.')
 			else:
-				self.parse_flow(row.sheet_name, row.data_sheet, row.data_row_id, row.extra_data_sheets, rapidpro_container)
+				self.parse_flow(row.sheet_name[0], row.data_sheet, row.data_row_id, row.extra_data_sheets, rapidpro_container)
 		return rapidpro_container	
 
 	def parse_flow(self, sheet_name, data_sheet, data_row_id, extra_data_sheets, rapidpro_container, parse_as_block=False):

--- a/parsers/creation/contentindexparser.py
+++ b/parsers/creation/contentindexparser.py
@@ -76,11 +76,11 @@ class ContentIndexParser:
 			if row.data_sheet and not row.data_row_id:
 				data_rows = self.get_all_data_model_instances(row.data_sheet)
 				for data_row_id in data_rows.keys():
-					self.parse_flow(row.sheet_name, row.data_sheet, data_row_id, [], rapidpro_container)
+					self.parse_flow(row.sheet_name, row.data_sheet, data_row_id, row.extra_data_sheets, rapidpro_container)
 			elif not row.data_sheet and row.data_row_id:
 				raise ValueError(f'For create_flow, if data_row_id is provided, data_sheet must also be provided.')
 			else:
-				self.parse_flow(row.sheet_name, row.data_sheet, row.data_row_id, [], rapidpro_container)
+				self.parse_flow(row.sheet_name, row.data_sheet, row.data_row_id, row.extra_data_sheets, rapidpro_container)
 		return rapidpro_container	
 
 	def parse_flow(self, sheet_name, data_sheet, data_row_id, extra_data_sheets, rapidpro_container, parse_as_block=False):

--- a/parsers/creation/contentindexrowmodel.py
+++ b/parsers/creation/contentindexrowmodel.py
@@ -3,10 +3,10 @@ from typing import List
 
 class ContentIndexRowModel(ParserModel):
     type: str = ''
-    sheet_name: str = ''
+    new_name: str = ''
+    sheet_name: List[str] = []
     data_sheet: str = ''
     data_row_id: str = ''
     extra_data_sheets: List[str] = []
-    new_name: str = ''
     data_model: str = ''
     status: str = ''

--- a/parsers/creation/contentindexrowmodel.py
+++ b/parsers/creation/contentindexrowmodel.py
@@ -1,10 +1,12 @@
 from parsers.common.rowparser import ParserModel
+from typing import List
 
 class ContentIndexRowModel(ParserModel):
     type: str = ''
     sheet_name: str = ''
     data_sheet: str = ''
     data_row_id: str = ''
+    extra_data_sheets: List[str] = []
     new_name: str = ''
     data_model: str = ''
     status: str = ''

--- a/parsers/creation/flowparser.py
+++ b/parsers/creation/flowparser.py
@@ -371,7 +371,7 @@ class FlowParser:
     def _parse_insert_as_block_row(self, row):
         if self.content_index_parser is None:
             raise ValueError('insert_as_block only works if FlowParser has a ContentIndexParser')
-        node_group = self.content_index_parser.get_node_group(row.mainarg_flow_name, row.data_sheet, row.data_row_id)
+        node_group = self.content_index_parser.get_node_group(row.mainarg_flow_name, row.data_sheet, row.data_row_id, row.extra_data_sheets)
         for edge in row.edges:
             self._add_row_edge(edge, node_group.entry_node().uuid)
         self.append_node_group(node_group, row.row_id)

--- a/parsers/creation/flowrowmodel.py
+++ b/parsers/creation/flowrowmodel.py
@@ -49,6 +49,7 @@ class FlowRowModel(ParserModel):
     mainarg_iterlist: list = [] # no specified type of elements
     data_sheet: str = ''
     data_row_id: str = ''
+    extra_data_sheets: List[str] = []
     choices: List[str] = []
     save_name: str = ''
     image: str = ''

--- a/parsers/creation/tests/datarowmodels/listmodel.py
+++ b/parsers/creation/tests/datarowmodels/listmodel.py
@@ -1,0 +1,14 @@
+from parsers.creation.datarowmodel import DataRowModel
+from typing import List
+
+class ListRowModel(DataRowModel):
+	# Because this defines the content of a datasheet,
+	# it inherits DataRowModel, which gives it the ID column.
+	messages: List[str]
+
+class LookupRowModel(DataRowModel):
+	# Because this defines the content of a datasheet,
+	# it inherits DataRowModel, which gives it the ID column.
+	happy: str
+	sad: str
+	neutral: str

--- a/parsers/creation/tests/test_contentindexparser.py
+++ b/parsers/creation/tests/test_contentindexparser.py
@@ -193,3 +193,69 @@ class TestParsing(unittest.TestCase):
             "I'm Sad1",  # we're taking the hard exit now, leaving the flow.
         ]
         self.compare_messages(render_output, 'my_basic_flow', messages_exp, Context(inputs=['happy', 'else', 'sad']))
+
+    def test_insert_as_block_with_extra_data(self):
+        ci_sheet = (
+            'type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n'
+            'template_definition,my_template,,,,,\n'
+            'create_flow,my_basic_flow,,,,,\n'
+            'data_sheet,nesteddata,,,,ListRowModel,\n'
+            'data_sheet,string_lookup,,,,LookupRowModel,\n'
+        )
+        nesteddata = (
+            'ID,messages.1,messages.2\n'
+            'row1,hello,nicetosee\n'
+            'row2,nicetosee,bye\n'
+        )
+        string_lookup = (
+            'ID,happy,sad,neutral\n'
+            'hello,Hello :),Hello :(,Hello\n'
+            'bye,Bye :),Bye :(,Bye\n'
+            'nicetosee,Nice to see you :),Not nice to see you :(,Nice to see you\n'
+        )
+        my_template = (
+            'row_id,type,from,condition,message_text\n'
+            '1,split_by_value,,,@field.mood\n'
+            ',send_message,1,happy,{% for msg in messages %}{{_data.string_lookup[msg].happy}}{% endfor %}\n'
+            ',send_message,1,sad,{% for msg in messages %}{{_data.string_lookup[msg].sad}}{% endfor %}\n'
+            ',send_message,1,,{% for msg in messages %}{{_data.string_lookup[msg].neutral}}{% endfor %}\n'
+        )
+        my_basic_flow = (
+            'row_id,type,from,message_text,data_sheet,data_row_id,extra_data_sheets\n'
+            ',send_message,start,Some text,,,\n'
+            ',insert_as_block,,my_template,nesteddata,row1,string_lookup\n'
+            ',send_message,,Intermission,,,\n'
+            ',insert_as_block,,my_template,nesteddata,row2,string_lookup\n'
+        )
+        sheet_dict = {
+            'nesteddata' : nesteddata,
+            'my_template' : my_template,
+            'my_basic_flow' : my_basic_flow,
+            'string_lookup' : string_lookup,
+        }
+
+        sheet_reader = MockSheetReader(ci_sheet, sheet_dict)
+        ci_parser = ContentIndexParser(sheet_reader, 'parsers.creation.tests.datarowmodels.listmodel')
+        container = ci_parser.parse_all_flows()
+        render_output = container.render()
+        messages_exp = [
+            'Some text',
+            'Hello :)Nice to see you :)',
+            'Intermission',
+            'Nice to see you :)Bye :)',
+        ]
+        self.compare_messages(render_output, 'my_basic_flow', messages_exp, Context(variables={'@field.mood':'happy'}))
+        messages_exp = [
+            'Some text',
+            'Hello :(Not nice to see you :(',
+            'Intermission',
+            'Not nice to see you :(Bye :(',
+        ]
+        self.compare_messages(render_output, 'my_basic_flow', messages_exp, Context(variables={'@field.mood':'sad'}))
+        messages_exp = [
+            'Some text',
+            'HelloNice to see you',
+            'Intermission',
+            'Nice to see youBye',
+        ]
+        self.compare_messages(render_output, 'my_basic_flow', messages_exp, Context(variables={'@field.mood':'something else'}))

--- a/parsers/creation/tests/test_contentindexparser.py
+++ b/parsers/creation/tests/test_contentindexparser.py
@@ -196,16 +196,18 @@ class TestParsing(unittest.TestCase):
 
     def test_insert_as_block_with_extra_data(self):
         ci_sheet = (
-            'type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n'
-            'template_definition,my_template,,,,,\n'
-            'create_flow,my_basic_flow,,,,,\n'
-            'data_sheet,nesteddata,,,,ListRowModel,\n'
-            'data_sheet,string_lookup,,,,LookupRowModel,\n'
+            'type,sheet_name,data_sheet,data_row_id,extra_data_sheets,new_name,data_model,status\n'
+            'template_definition,my_template,,,,,,\n'
+            'create_flow,my_template,nesteddata,row3,string_lookup,,,\n'
+            'create_flow,my_basic_flow,,,,,,\n'
+            'data_sheet,nesteddata,,,,,ListRowModel,\n'
+            'data_sheet,string_lookup,,,,,LookupRowModel,\n'
         )
         nesteddata = (
             'ID,messages.1,messages.2\n'
             'row1,hello,nicetosee\n'
             'row2,nicetosee,bye\n'
+            'row3,hello,bye\n'
         )
         string_lookup = (
             'ID,happy,sad,neutral\n'
@@ -259,3 +261,8 @@ class TestParsing(unittest.TestCase):
             'Nice to see youBye',
         ]
         self.compare_messages(render_output, 'my_basic_flow', messages_exp, Context(variables={'@field.mood':'something else'}))
+
+        messages_exp = [
+            'Hello :)Bye :)',
+        ]
+        self.compare_messages(render_output, 'my_template - row3', messages_exp, Context(variables={'@field.mood':'happy'}))

--- a/parsers/creation/tests/test_contentindexparser.py
+++ b/parsers/creation/tests/test_contentindexparser.py
@@ -88,6 +88,33 @@ class TestParsing(unittest.TestCase):
         self.assertEqual(datamodelB.value1, '1B')
         self.assertEqual(datamodelB.value2, '2B')
 
+    def test_concat(self):
+        ci_sheet = (
+            'type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n'
+            'data_sheet,simpleA;simpleB,,,simpledata,SimpleRowModel,\n'
+        )
+        simpleA = (
+            'ID,value1,value2\n'
+            'rowA,1A,2A\n'
+        )
+        simpleB = (
+            'ID,value1,value2\n'
+            'rowB,1B,2B\n'
+        )
+        sheet_dict = {
+            'simpleA' : simpleA,
+            'simpleB' : simpleB,
+        }
+
+        sheet_reader = MockSheetReader(ci_sheet, sheet_dict)
+        ci_parser = ContentIndexParser(sheet_reader, 'parsers.creation.tests.datarowmodels.simplemodel')
+        datamodelA = ci_parser.get_data_model_instance('simpledata', 'rowA')
+        datamodelB = ci_parser.get_data_model_instance('simpledata', 'rowB')
+        self.assertEqual(datamodelA.value1, '1A')
+        self.assertEqual(datamodelA.value2, '2A')
+        self.assertEqual(datamodelB.value1, '1B')
+        self.assertEqual(datamodelB.value2, '2B')
+
     def test_generate_flows(self):
         ci_sheet = (
             'type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n'


### PR DESCRIPTION
Allows passing entire sheets as additional data to template instances. The list of sheets should go in the column `extra_data_sheets`. The content of the sheet `sheet_name` can then be accessed within templates via `_data.sheet_name`. A row of the sheet `sheet_name` with id `"my_row"` can then be accessed via `_data.sheet_name["my_row"]`, and the fields of the row can be accessed as usual.

Use cases:
- `insert_as_block` (in flow/template definitions)
- `create_flow` (in content index sheets)
