### PR TITLE
Cell parser separators

### DIFF
--- a/parsers/common/cellparser.py
+++ b/parsers/common/cellparser.py
@@ -8,6 +8,9 @@ class CellParser:
         def __init__(self, val=False):
             self.boolean = val
 
+    def escape_string(string):
+        return string.replace('\\', '\\\\').replace('|', '\\|').replace(';', '\\;')
+
     def __init__(self):
         self.native_env = NativeEnvironment(variable_start_string='{@', variable_end_string='@}')
 

--- a/parsers/common/cellparser.py
+++ b/parsers/common/cellparser.py
@@ -1,4 +1,4 @@
-from jinja2 import Template
+from jinja2 import Environment
 from jinja2.nativetypes import NativeEnvironment
 
 
@@ -12,7 +12,10 @@ class CellParser:
         return string.replace('\\', '\\\\').replace('|', '\\|').replace(';', '\\;')
 
     def __init__(self):
+        self.env = Environment()
+        self.env.filters['escape'] = CellParser.escape_string
         self.native_env = NativeEnvironment(variable_start_string='{@', variable_end_string='@}')
+        self.native_env.filters['escape'] = CellParser.escape_string
 
     def split_into_lists(self, string):
         l1 = self.split_by_separator(string, '|')
@@ -84,9 +87,5 @@ class CellParser:
             template = self.native_env.from_string(stripped_value)
             return template.render(context)
         else:
-            try:
-                return Template(value).render(context)
-            except Exception as e:
-                print(value, context, str(e))
-                raise Exception
-
+            template = self.env.from_string(stripped_value)
+            return template.render(context)

--- a/parsers/common/cellparser.py
+++ b/parsers/common/cellparser.py
@@ -1,46 +1,70 @@
-from collections import defaultdict
-
 from jinja2 import Template
 from jinja2.nativetypes import NativeEnvironment
-
-def get_separators(value):
-    # TODO: Discuss escape characters
-    separators = ['|', ';', ':']
-
-    found_separators = [s for s in separators if s in value]
-    iterator = iter(found_separators)
-
-    return [next(iterator, None) for _ in range(0, 3)]
-
-
-def get_object_from_cell_value(value):
-    separator_1, separator_2, _ = get_separators(value)
-    obj = defaultdict(str)
-
-    members = value.split(separator_1)
-    for member in members:
-        key, value = member.split(separator_2)
-        obj[key] = value
-    return obj
 
 
 class CellParser:
 
+    class BooleanWrapper:
+        def __init__(self, val=False):
+            self.boolean = val
+
     def __init__(self):
         self.native_env = NativeEnvironment(variable_start_string='{@', variable_end_string='@}')
 
-    def parse(self, value, context={}):
-        value = self.parse_as_string(value, context)
-
-        # TODO: Implement splitting properly
-        # We do the type check because parse_as_string may return a non-string
-        # in the case of {@ @} templating.
-        if type(value) == str and ';' in value:
-            return value.split(';')
+    def split_into_lists(self, string):
+        l1 = self.split_by_separator(string, '|')
+        if type(l1) == str:
+            output = self.split_by_separator(string, ';')
         else:
-            return value
+            output = [self.split_by_separator(s, ';') for s in l1]
+        return self.cleanse(output)
 
-    def parse_as_string(self, value, context={}):
+    def cleanse(self, nested_list):
+        # Unescape escaped characters (\, |, ;) 
+        if type(nested_list) == str:
+            return nested_list.replace('\\\\', '\1') \
+                              .replace('\\|', '|') \
+                              .replace('\\;', ';') \
+                              .replace('\1', '\\')
+        else:
+            return [self.cleanse(l) for l in nested_list]        
+
+    def split_by_separator(self, string, sep):
+        pos = 0
+        sep_locations = []
+        while pos < len(string):
+            c = string[pos]
+            if c == '\\':
+                pos += 1
+            elif c == sep:
+                sep_locations.append(pos)
+            pos += 1
+        if not sep_locations:
+            # No separators found: return a string, not a list
+            return string
+        else:
+            if len(string) - 1 in sep_locations:
+                # Special case: Last character is a separator.
+                # Here we don't put '' at the end of the list
+                locations = [-1] + sep_locations[:-1] + [len(string)-1]
+            else:
+                locations = [-1] + sep_locations + [len(string)]
+            return [string[locations[i]+1:locations[i+1]] for i in range(len(locations)-1)]
+
+    def parse(self, value, context={}):
+        is_object = CellParser.BooleanWrapper()
+        value = self.parse_as_string(value, context, is_object)
+        # {@ @} templating returns an object that is not processed further.
+        if is_object.boolean:
+            return value
+        else:
+            return self.split_into_lists(value)
+
+    def parse_as_string(self, value, context={}, is_object=None):
+        # is_object is a pass-by-reference boolean, realised via
+        # the class BooleanWrapper, to indicate to the caller
+        # whether the parsing result represents an object that
+        # is not to be processed any further.
         if value is None:
             return ''
         if not context and '{' not in value:
@@ -50,7 +74,16 @@ class CellParser:
         if stripped_value.startswith('{@') and stripped_value.endswith('@}'):
             # Special case: Return a python object rather than a string,
             # if possible.
+            # Ensure this is a single template, not e.g. '{@ x @} {@ y @}'
+            assert stripped_value[2:].find('{@') == -1
+            if is_object is not None:
+                is_object.boolean = True
             template = self.native_env.from_string(stripped_value)
             return template.render(context)
         else:
-            return Template(value).render(context)
+            try:
+                return Template(value).render(context)
+            except Exception as e:
+                print(value, context, str(e))
+                raise Exception
+

--- a/parsers/common/tests/test_cellparser.py
+++ b/parsers/common/tests/test_cellparser.py
@@ -99,6 +99,15 @@ class TestCellParser(unittest.TestCase):
         out = self.parser.parse('{% for e in list %}{{e}};{% endfor %}', context=context)
         self.assertEqual(out, ['a', 'b', 'c'])
 
+    def test_escape_filter(self):
+        out = self.parser.parse('{{"a;b;c"}}')
+        self.assertEqual(out, ['a', 'b', 'c'])
+        out = self.parser.parse('{{"a;b;c"|escape}}')
+        self.assertEqual(out, 'a;b;c')
+        string = '\\|;\\'
+        out = self.parser.parse('{{string|escape}}', context={'string':string})
+        self.assertEqual(out, string)
+
     def test_parse_native_tpye(self):
         out = self.parser.parse_as_string('{@(1,2,[3,"a"])@}')
         self.assertEqual(out, (1,2,[3,'a']))

--- a/parsers/common/tests/test_cellparser.py
+++ b/parsers/common/tests/test_cellparser.py
@@ -67,6 +67,8 @@ class TestStringSplitter(unittest.TestCase):
         self.compare_split_into_lists('1;2|3;4;', [['1', '2'], ['3', '4']])
         self.compare_split_into_lists('1;2|3;4\\;', [['1', '2'], ['3', '4;']])
         self.compare_split_into_lists('1;2|3;4\\|', [['1', '2'], ['3', '4|']])
+        self.compare_split_into_lists(CellParser.escape_string('|;;|\\;\\\\\\|'), '|;;|\\;\\\\\\|')
+
 
 class TestCellParser(unittest.TestCase):
 


### PR DESCRIPTION
Support two types of separators to encode lists in cells: | and ;
Escape sequences for these characters to be used as strings are \| and \; and \ can be escaped as \\

Fixes #51 