### PR TITLE
Ignore rows in excluded blocks

### DIFF
--- a/parsers/common/sheetparser.py
+++ b/parsers/common/sheetparser.py
@@ -35,12 +35,13 @@ class SheetParser:
     def remove_bookmark(self, name):
         self.bookmarks.pop(name)
 
-    def parse_next_row(self):
+    def parse_next_row(self, omit_templating=False):
         try:
             input_row = next(self.iterator)
         except StopIteration:
             return None
-        row = self.row_parser.parse_row(input_row, self.context)
+        context = self.context if not omit_templating else None
+        row = self.row_parser.parse_row(input_row, context)
         return row
 
     def parse_all(self):

--- a/parsers/common/tests/mock_sheetparser.py
+++ b/parsers/common/tests/mock_sheetparser.py
@@ -17,7 +17,7 @@ class MockSheetParser(SheetParser):
         self.iterator = iter(self.input_rows)
         self.context = copy.deepcopy(context)
 
-    def parse_next_row(self):
+    def parse_next_row(self, omit_templating=False):
         # Simply return the input.
         try:
             input_row = next(self.iterator)

--- a/parsers/creation/contentindexparser.py
+++ b/parsers/creation/contentindexparser.py
@@ -142,8 +142,8 @@ class ContentIndexParser:
 		for arg_def, arg in zip(arg_defs, args + args_padding):
 			if arg_def.name in context:
 				raise ValueError(f'Template argument "{arg_def.name}" doubly defined in context')
-			arg_value = arg or arg_def.default_value
-			if not arg_value:
+			arg_value = arg if arg != '' else arg_def.default_value
+			if arg_value == '':
 				raise ValueError(f'Required template argument "{arg_def.name}" not provided')
 			if arg_def.type == 'sheet':
 				context[arg_def.name] = self.data_sheets[arg_value]

--- a/parsers/creation/flowparser.py
+++ b/parsers/creation/flowparser.py
@@ -304,7 +304,7 @@ class FlowParser:
         return flow_container
 
     def _parse_block(self, depth=0, block_type='root_block', omit_content=False):
-        row = self.sheet_parser.parse_next_row()
+        row = self.sheet_parser.parse_next_row(omit_templating=omit_content)
         while not self._is_end_of_block(block_type, row):
             if omit_content or not row.include_if:
                 if row.type == 'begin_for':
@@ -349,7 +349,7 @@ class FlowParser:
                     self.append_node_group(new_node_group, row.row_id)
                 else:
                     self._parse_row(row)
-            row = self.sheet_parser.parse_next_row()
+            row = self.sheet_parser.parse_next_row(omit_templating=omit_content)
 
     def _is_end_of_block(self, block_type, row):
         block_end_map = {


### PR DESCRIPTION
We now ignore rows that are inside of blocks that are skipped via `include_if`.
The `include_if` row is still fully parsed, so in that case #64  still persists.
But for now, this should at least create a workaround by allowing wrapping such lines in a block.