### PR TITLE
Validate router cases

### DIFF
--- a/parsers/creation/tests/test_to_row_model.py
+++ b/parsers/creation/tests/test_to_row_model.py
@@ -160,7 +160,7 @@ class TestFlowContainer(TestToRowModels):
         node2 = BasicNode()
 
         # The arguments for this choice is [group uuid, group name]
-        node1.add_choice(case.variable, case.type, [row_data1.obj_id, case.value], case.name, node2.uuid)
+        node1.add_choice(case.variable, case.type or 'has_group', [row_data1.obj_id, case.value], case.name, node2.uuid)
         container.add_node(node1)
 
         action2 = SetContactFieldAction(row_data2.save_name, row_data2.mainarg_value)
@@ -303,7 +303,7 @@ class TestFlowContainer(TestToRowModels):
 
         node1 = EnterFlowNode(row_data1.mainarg_flow_name, row_data1.obj_id)
         node2 = BasicNode()
-        node1.add_choice(case1.variable, case1.type, [case1.value], case1.name, node2.uuid, is_default=True)
+        node1.add_choice(case1.variable, case1.type or 'has_only_text', [case1.value], case1.name, node2.uuid, is_default=True)
         container.add_node(node1)
 
         action2 = SetRunResultAction(row_data2.save_name, row_data2.mainarg_value)

--- a/rapidpro/models/routers.py
+++ b/rapidpro/models/routers.py
@@ -380,11 +380,24 @@ class RouterCategory:
 
 
 class RouterCase:
+    NO_ARGS_TESTS = {
+        "has_date", 
+        "has_email", 
+        "has_error", 
+        "has_number", 
+        "has_state", 
+        "has_text", 
+        "has_time", 
+    }
+
     def __init__(self, comparison_type, arguments, category_uuid, uuid=None):
         self.uuid = uuid or generate_new_uuid()
         self.type = comparison_type
-        self.arguments = arguments
         self.category_uuid = category_uuid
+        if self.type in RouterCase.NO_ARGS_TESTS:
+            self.arguments = []
+        else:
+            self.arguments = arguments
 
     def from_dict(data):
         return RouterCase(data["type"], data["arguments"], data["category_uuid"], data["uuid"])

--- a/rapidpro/models/routers.py
+++ b/rapidpro/models/routers.py
@@ -390,6 +390,39 @@ class RouterCase:
         "has_time", 
     }
 
+    TEST_VALIDATIONS = {
+        "all_words" : lambda x: len(x) == 1,
+        "has_any_word" : lambda x: len(x) == 1,
+        "has_beginning" : lambda x: len(x) == 1,
+        "has_category" : lambda x: len(x) >= 1,
+        "has_date" : lambda x: len(x) == 0,
+        "has_date_eq" : lambda x: len(x) == 1,
+        "has_date_gt" : lambda x: len(x) == 1,
+        "has_date_lt" : lambda x: len(x) == 1,
+        "has_district" : lambda x: len(x) == 1,
+        "has_email" : lambda x: len(x) == 0,
+        "has_error" : lambda x: len(x) == 0,
+        "has_group" : lambda x: len(x) in {1, 2},  # uuid obligatory, name optional?
+        "has_intent" : lambda x: len(x) == 2,
+        "has_number" : lambda x: len(x) == 0,
+        "has_number_between" : lambda x: len(x) == 2,
+        "has_number_eq" : lambda x: len(x) == 1,
+        "has_number_gt" : lambda x: len(x) == 1,
+        "has_number_gte" : lambda x: len(x) == 1,
+        "has_number_lt" : lambda x: len(x) == 1,
+        "has_number_lte" : lambda x: len(x) == 1,
+        "has_only_phrase" : lambda x: len(x) == 1,
+        "has_only_text" : lambda x: len(x) == 1,
+        "has_pattern" : lambda x: len(x) == 1,
+        "has_phone" : lambda x: len(x) in {0, 1},
+        "has_phrase" : lambda x: len(x) == 1,
+        "has_state" : lambda x: len(x) == 0,
+        "has_text" : lambda x: len(x) == 0,
+        "has_time" : lambda x: len(x) == 0,
+        "has_top_intent" : lambda x: len(x) == 2,
+        "has_ward" : lambda x: len(x) == 2,
+    }
+
     def __init__(self, comparison_type, arguments, category_uuid, uuid=None):
         self.uuid = uuid or generate_new_uuid()
         self.type = comparison_type
@@ -398,11 +431,19 @@ class RouterCase:
             self.arguments = []
         else:
             self.arguments = arguments
+        self.validate()
 
     def from_dict(data):
         return RouterCase(data["type"], data["arguments"], data["category_uuid"], data["uuid"])
 
+    def validate(self):
+        if not self.type in RouterCase.TEST_VALIDATIONS:
+            raise ValueError(f'Invalid router test type: "{self.type}"')
+        if not RouterCase.TEST_VALIDATIONS[self.type](self.arguments):
+            print(f'Warning: Invalid number of arguments {len(self.arguments)} for router test type "{self.type}"')
+
     def render(self):
+        self.validate()
         return {
             'uuid': self.uuid,
             'type': self.type,

--- a/rapidpro/tests/test_routers.py
+++ b/rapidpro/tests/test_routers.py
@@ -6,9 +6,9 @@ from rapidpro.models.routers import SwitchRouter, RandomRouter
 class TestRouters(unittest.TestCase):
     def setUp(self) -> None:
         self.switch_router = SwitchRouter(operand='@input.text', result_name=None, wait_timeout=600)
-        self.switch_router.add_choice('@input.text', 'has_any_word', None, 'Add', 'test_destination_1',
+        self.switch_router.add_choice('@input.text', 'has_any_word', ['word'], 'Add', 'test_destination_1',
                                       is_default=False)
-        self.switch_router.add_choice('@input.text', 'has_any_word', None, 'Other', 'test_destination_2',
+        self.switch_router.add_choice('@input.text', 'has_any_word', ['word'], 'Other', 'test_destination_2',
                                       is_default=True)
         self.switch_router.update_no_response_category('no_response_destination_uuid')
 
@@ -27,7 +27,7 @@ class TestRouters(unittest.TestCase):
         self.assertEqual(render_output['type'], 'switch')
         self.assertEqual(render_output['operand'], '@input.text')
         self.assertEqual(render_output['cases'][0]['type'], 'has_any_word')
-        self.assertEqual(render_output['cases'][0]['arguments'], None)
+        self.assertEqual(render_output['cases'][0]['arguments'], ['word'])
 
         self.assertEqual(len(render_output['categories']), 3)
         self.assertEqual(render_output['categories'][0]['name'], 'Add')
@@ -112,3 +112,9 @@ class TestNoArgsTests(unittest.TestCase):
         self.assertEqual(render_output['categories'][1]['name'], 'Other')
         self.assertEqual(switch_router.default_category.exit.destination_uuid, None)
         self.assertEqual(switch_router.categories[0].exit.destination_uuid, 'test_destination_1')
+
+    def test_invalid_test(self):
+        switch_router = SwitchRouter(operand='@fields.field')
+        with self.assertRaises(ValueError):
+            switch_router.add_choice('@fields.field', 'has_junk', ['junk'], 'Has Just', 'test_destination_1',
+                                          is_default=False)

--- a/rapidpro/tests/test_routers.py
+++ b/rapidpro/tests/test_routers.py
@@ -95,3 +95,20 @@ class TestDuplicateChoices(unittest.TestCase):
         # There should be exactly one Word category, internally
         self.assertEqual(len(cats), 1)
         self.assertEqual(cats[0].exit.destination_uuid, 'test_destination_3')
+
+
+class TestNoArgsTests(unittest.TestCase):
+
+    def test_no_args_tests(self):
+        switch_router = SwitchRouter(operand='@fields.field')
+        switch_router.add_choice('@fields.field', 'has_text', ['junk'], 'Has Text', 'test_destination_1',
+                                      is_default=False)
+
+        render_output = switch_router.render()
+        self.assertEqual(len(render_output['cases']), 1)
+        self.assertEqual(len(render_output['categories']), 2)
+        self.assertEqual(render_output['cases'][0]['arguments'], [])
+        self.assertEqual(render_output['categories'][0]['name'], 'Has Text')
+        self.assertEqual(render_output['categories'][1]['name'], 'Other')
+        self.assertEqual(switch_router.default_category.exit.destination_uuid, None)
+        self.assertEqual(switch_router.categories[0].exit.destination_uuid, 'test_destination_1')


### PR DESCRIPTION
- Ensure router test type is valid
- Ensure empty args for router tests that should have empty args
- Warn for incorrect number of arguments for other router tests

fixes #70
fixes #71 