### PR TITLE
Tags for content index

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import json
 import argparse
 
 from parsers.creation.contentindexparser import ContentIndexParser
+from parsers.creation.tagmatcher import TagMatcher
 from parsers.sheets.csv_sheet_reader import CSVSheetReader
 from parsers.sheets.xlsx_sheet_reader import XLSXSheetReader
 from parsers.sheets.google_sheet_reader import GoogleSheetReader
@@ -27,6 +28,7 @@ def main():
     parser.add_argument('output', help='Filename')
     parser.add_argument('--format', required=True, choices=["csv", "xlsx", "google_sheets"], help='Sheet format for reading/writing.')
     parser.add_argument('--datamodels', help='Module defining models for data sheets. E.g. if the definitions reside in ./myfolder/mysubfolder/mymodelsfile.py, then this argument should be myfolder.mysubfolder.mymodelsfile')
+    parser.add_argument('--tags', nargs='*', help='Tags to filter the content index sheet. A sequence of lists, with each list starting with an integer (tag position) followed by tags to include for this position. Example: 1 foo bar 2 baz means: only include rows if tags:1 is empty, foo or bar, and tags:2 is empty or baz.')
     args = parser.parse_args()
 
     if args.command != 'create_flows':
@@ -43,7 +45,8 @@ def main():
         print(f"Format {args.format} currently unsupported.")
         return
 
-    ci_parser = ContentIndexParser(sheet_reader, args.datamodels)
+    tag_matcher = TagMatcher(args.tags)
+    ci_parser = ContentIndexParser(sheet_reader, args.datamodels, tag_matcher=tag_matcher)
     output = ci_parser.parse_all_flows()
     json.dump(output.render(), open(args.output, 'w'), indent=4)
     

--- a/parsers/creation/contentindexparser.py
+++ b/parsers/creation/contentindexparser.py
@@ -4,6 +4,7 @@ from .contentindexrowmodel import ContentIndexRowModel
 from parsers.common.cellparser import CellParser
 from parsers.common.sheetparser import SheetParser
 from parsers.common.rowparser import RowParser
+from parsers.creation.tagmatcher import TagMatcher
 from rapidpro.models.containers import RapidProContainer
 from parsers.creation.flowparser import FlowParser
 from logger.logger import get_logger, logging_context
@@ -19,8 +20,9 @@ class TemplateSheet:
 
 class ContentIndexParser:
 
-	def  __init__(self, sheet_reader, user_data_model_module_name=None):
+	def  __init__(self, sheet_reader, user_data_model_module_name=None, tag_matcher=TagMatcher()):
 		self.sheet_reader = sheet_reader
+		self.tag_matcher = tag_matcher
 		self.template_sheets = {}  # values: tablib tables
 		self.data_sheets = {}  # values: OrderedDicts of RowModels
 		self.flow_definition_rows = []  # list of ContentIndexRowModel
@@ -38,6 +40,8 @@ class ContentIndexParser:
 			logging_prefix = f"{content_index_name} | row {row_idx+2}"
 			with logging_context(logging_prefix):
 				if row.status == 'draft':
+					continue
+				if not self.tag_matcher.matches(row.tags):
 					continue
 				if row.type == 'content_index':
 					if not len(row.sheet_name) == 1:

--- a/parsers/creation/contentindexrowmodel.py
+++ b/parsers/creation/contentindexrowmodel.py
@@ -16,6 +16,7 @@ class ContentIndexRowModel(ParserModel):
     template_arguments: list = []
     data_model: str = ''
     status: str = ''
+    tags: List[str] = []
 
     def field_name_to_header_name(field):
         if "template_argument_definitions":

--- a/parsers/creation/tagmatcher.py
+++ b/parsers/creation/tagmatcher.py
@@ -1,0 +1,25 @@
+import collections
+
+class TagMatcher:
+	def __init__(self, params=[]):		
+		self.tag_patterns = collections.defaultdict(list)
+		current_index = None
+		for param in params:
+			try:
+				val = int(param) - 1
+			except ValueError:
+				val = None
+			if val is not None:
+				current_index = val
+			else:
+				if current_index is None:
+					raise ValueError("Tags parameter must start with a number indicating the tag position.")
+				self.tag_patterns[current_index].append(param)
+
+	def matches(self, tags):
+		matches = True
+		for i, tag in enumerate(tags):
+			if tag and i in self.tag_patterns and tag not in self.tag_patterns[i]:
+				matches = False
+		return matches
+

--- a/parsers/creation/tests/test_contentindexparser.py
+++ b/parsers/creation/tests/test_contentindexparser.py
@@ -3,6 +3,7 @@ import json
 
 from .mock_sheetreader import MockSheetReader
 from parsers.creation.contentindexparser import ContentIndexParser
+from parsers.creation.tagmatcher import TagMatcher
 from tests.utils import traverse_flow, Context
 
 class TestParsing(unittest.TestCase):
@@ -17,6 +18,9 @@ class TestParsing(unittest.TestCase):
                 self.assertEqual(actions, actions_exp)
         if not flow_found:
             self.assertTrue(False, msg=f'Flow with name "{flow_name}" does not exist in output.')
+
+    def get_flow_names(self, render_output):
+        return {flow["name"] for flow in render_output["flows"]}
 
     def test_basic_template_definition(self):
         ci_sheet = (
@@ -393,3 +397,64 @@ class TestParsing(unittest.TestCase):
             'hello',
         ]
         self.compare_messages(render_output, 'flow - id2', messages_exp)
+
+
+    def test_tags(self):
+        ci_sheet = (
+            'type,sheet_name,new_name,template_arguments,tags.1,tags.2\n'
+            'template_definition,flow,,arg,,\n'
+            'create_flow,flow,flow-world,World,,\n'
+            'create_flow,flow,flow-t1,Tag1Only,tag1,\n'
+            'create_flow,flow,flow-b1,Bag1Only,bag1,\n'
+            'create_flow,flow,flow-t2,Tag2Only,,tag2\n'
+            'create_flow,flow,flow-b2,Bag2Only,,bag2\n'
+            'create_flow,flow,flow-t1t2,Tag1Tag2,tag1,tag2\n'
+            'create_flow,flow,flow-t1b2,Tag1Bag2,tag1,bag2\n'
+            'create_flow,flow,flow-b1t2,Bag1Tag2,bag1,tag2\n'
+        )
+        flow = (
+            '"row_id","type","from","loop_variable","include_if","message_text"\n'
+            ',"send_message",,,,"Hello {{arg}}"\n'
+        )
+        sheet_dict = {
+            'flow' : flow,
+        }
+
+        sheet_reader = MockSheetReader(ci_sheet, sheet_dict)
+        ci_parser = ContentIndexParser(sheet_reader, 'parsers.creation.tests.datarowmodels.evalmodels')
+        container = ci_parser.parse_all_flows()
+        render_output = container.render()
+        self.assertEqual(self.get_flow_names(render_output), {"flow-world", "flow-t1", "flow-b1", "flow-t2", "flow-b2", "flow-t1t2", "flow-t1b2", "flow-b1t2"})
+        self.compare_messages(render_output, 'flow-world', ['Hello World'])
+        self.compare_messages(render_output, 'flow-t1', ['Hello Tag1Only'])
+        self.compare_messages(render_output, 'flow-b1', ['Hello Bag1Only'])
+        self.compare_messages(render_output, 'flow-t2', ['Hello Tag2Only'])
+        self.compare_messages(render_output, 'flow-b2', ['Hello Bag2Only'])
+        self.compare_messages(render_output, 'flow-t1t2', ['Hello Tag1Tag2'])
+        self.compare_messages(render_output, 'flow-t1b2', ['Hello Tag1Bag2'])
+        self.compare_messages(render_output, 'flow-b1t2', ['Hello Bag1Tag2'])
+
+        tag_matcher = TagMatcher(["1", "tag1"])
+        ci_parser = ContentIndexParser(sheet_reader, 'parsers.creation.tests.datarowmodels.evalmodels', tag_matcher)
+        container = ci_parser.parse_all_flows()
+        render_output = container.render()
+        self.assertEqual(self.get_flow_names(render_output), {"flow-world", "flow-t1", "flow-t2", "flow-b2", "flow-t1t2", "flow-t1b2"})
+
+        tag_matcher = TagMatcher(["1", "tag1", "bag1"])
+        ci_parser = ContentIndexParser(sheet_reader, 'parsers.creation.tests.datarowmodels.evalmodels', tag_matcher)
+        container = ci_parser.parse_all_flows()
+        render_output = container.render()
+        self.assertEqual(self.get_flow_names(render_output), {"flow-world", "flow-t1", "flow-b1", "flow-t2", "flow-b2", "flow-t1t2", "flow-t1b2", "flow-b1t2"})
+
+        tag_matcher = TagMatcher(["1", "tag1", "2", "tag2"])
+        ci_parser = ContentIndexParser(sheet_reader, 'parsers.creation.tests.datarowmodels.evalmodels', tag_matcher)
+        container = ci_parser.parse_all_flows()
+        render_output = container.render()
+        self.assertEqual(self.get_flow_names(render_output), {"flow-world", "flow-t1","flow-t2","flow-t1t2"})
+
+        tag_matcher = TagMatcher(["5", "tag1", "bag1"])
+        ci_parser = ContentIndexParser(sheet_reader, 'parsers.creation.tests.datarowmodels.evalmodels', tag_matcher)
+        container = ci_parser.parse_all_flows()
+        render_output = container.render()
+        self.assertEqual(self.get_flow_names(render_output), {"flow-world", "flow-t1", "flow-b1", "flow-t2", "flow-b2", "flow-t1t2", "flow-t1b2", "flow-b1t2"})
+

--- a/parsers/creation/tests/test_tagmatcher.py
+++ b/parsers/creation/tests/test_tagmatcher.py
@@ -1,0 +1,40 @@
+import unittest
+from parsers.creation.tagmatcher import TagMatcher
+
+class TestTagMatcher(unittest.TestCase):
+
+    def test_empty_matcher(self):
+        tm = TagMatcher()
+        self.assertTrue(tm.matches([]))
+        self.assertTrue(tm.matches([""]))
+        self.assertTrue(tm.matches(["", ""]))
+        self.assertTrue(tm.matches(["tag1", "tag2"]))
+
+    def test_single_tag(self):
+        tm = TagMatcher(["1", "foo", "bar"])
+        self.assertTrue(tm.matches([]))
+        self.assertTrue(tm.matches([""]))
+        self.assertTrue(tm.matches(["", ""]))
+        self.assertTrue(tm.matches(["", "something"]))
+        self.assertTrue(tm.matches(["foo"]))
+        self.assertTrue(tm.matches(["bar"]))
+        self.assertTrue(tm.matches(["bar", "something"]))
+        self.assertFalse(tm.matches(["something"]))
+        self.assertFalse(tm.matches(["something", "foo"]))
+        self.assertFalse(tm.matches(["something", "bar"]))
+
+    def test_two_tags(self):
+        tm = TagMatcher(["1", "foo", "bar", "2", "baz"])
+        self.assertTrue(tm.matches([]))
+        self.assertTrue(tm.matches([""]))
+        self.assertTrue(tm.matches(["", ""]))
+        self.assertTrue(tm.matches(["", "baz"]))
+        self.assertTrue(tm.matches(["foo", ""]))
+        self.assertTrue(tm.matches(["foo", "baz"]))
+        self.assertTrue(tm.matches(["bar", "baz"]))
+        self.assertTrue(tm.matches(["foo"]))
+        self.assertTrue(tm.matches(["bar"]))
+        self.assertFalse(tm.matches(["bar", "something"]))
+        self.assertFalse(tm.matches(["something"]))
+        self.assertFalse(tm.matches(["something", "foo"]))
+        self.assertFalse(tm.matches(["something", "baz"]))

--- a/tests/input/example1/content_index.csv
+++ b/tests/input/example1/content_index.csv
@@ -1,5 +1,5 @@
-type,sheet_name,data_sheet,data_row_id,new_name,data_model,status
-create_flow,my_template,nesteddata,row1,,,
-create_flow,my_template,nesteddata,row2,,,
-create_flow,my_basic_flow,,,,,
-data_sheet,nesteddata,,,,NestedRowModel,
+type,sheet_name,data_sheet,data_row_id,new_name,data_model,status,tags.1,tags.2
+create_flow,my_template,nesteddata,row1,,,,advanced,type1
+create_flow,my_template,nesteddata,row2,,,,advanced,type2
+create_flow,my_basic_flow,,,,,,basic,
+data_sheet,nesteddata,,,,NestedRowModel,,,


### PR DESCRIPTION
Each row of the content index may now contain a list of tags.
`main.py` takes an optional argument `--tags` specifying tags to filter the rows of the content index by. This argument is a sequence of lists, each list starting with an integer indicating the index of the tag, followed by tags to filter by for this index. If a tag in the content index is empty, is it considered to be matching. For a row to be processed, the tags need to match for ALL of the specified indices.

*Example:* Take a look at `tests/input/example1/content_index.csv`
If we supply `--tags 1 advanced basic 2 type1` to `main.py` it means:
Only process rows of the content index where the first tag (tags.1) is either ‘advanced’, ‘basic’ or empty, and where the second tag (tags.1) is either ‘type1’ or empty.

You can try this out via
```main.py create_flows tests/input/example1/content_index.csv out.json --format=csv --datamodels=tests.input.example1.nestedmodel --tags 1 advanced basic 2 type1```