### PR TITLE
Migrate code style to black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 88

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Migrate code style to Black
+d2ca33e8553e19e4007ceb5083c8c398330083b0

--- a/src/rpft/logger/logger.py
+++ b/src/rpft/logger/logger.py
@@ -6,7 +6,7 @@ import sys
 LOGGER_NAME = "main"
 
 
-class LoggingContextHandler():
+class LoggingContextHandler:
     def __init__(self):
         self.context_variables = []
         self.processing_stack = []
@@ -47,7 +47,9 @@ class ContextFilter(logging.Filter):
         super(ContextFilter, self).__init__()
 
     def filter(self, record):
-        record.processing_stack = ' | '.join(logging_context_handler.get_processing_stack())
+        record.processing_stack = " | ".join(
+            logging_context_handler.get_processing_stack()
+        )
         record.context_variables = logging_context_handler.get_context_variables()
         return True
 
@@ -57,7 +59,7 @@ class ShutdownHandler(logging.FileHandler):
         super().emit(record)
         if record.levelno >= logging.CRITICAL:
             # raise Exception(self.format(record))
-            print(f'{self.format(record)}', file=sys.stderr)
+            print(f"{self.format(record)}", file=sys.stderr)
             sys.exit(1)
 
 
@@ -72,8 +74,10 @@ def initialize_main_logger():
     LOGGER.addFilter(context_filter)
     # We're currently not using the context_variables, so don't print them.
     # If needed, add "Context: %(context_variables)s" to the format string below
-    stdout_formatter = logging.Formatter("%(levelname)s: %(processing_stack)s: %(message)s\n")
-    stdout_handler = ShutdownHandler("errors.log", 'w')
+    stdout_formatter = logging.Formatter(
+        "%(levelname)s: %(processing_stack)s: %(message)s\n"
+    )
+    stdout_handler = ShutdownHandler("errors.log", "w")
     stdout_handler.setFormatter(stdout_formatter)
     LOGGER.addHandler(stdout_handler)
     return LOGGER

--- a/src/rpft/parsers/common/cellparser.py
+++ b/src/rpft/parsers/common/cellparser.py
@@ -7,50 +7,54 @@ LOGGER = get_logger()
 
 
 class CellParser:
-
     class BooleanWrapper:
         def __init__(self, val=False):
             self.boolean = val
 
     def escape_string(string):
-        return string.replace('\\', '\\\\').replace('|', '\\|').replace(';', '\\;')
+        return string.replace("\\", "\\\\").replace("|", "\\|").replace(";", "\\;")
+
     @contextfilter
     def evaluate_string(context, string):
         return eval(string, {}, context)
 
     def __init__(self):
         self.env = Environment()
-        self.env.filters['escape'] = CellParser.escape_string
-        self.env.filters['eval'] = CellParser.evaluate_string
-        self.native_env = NativeEnvironment(variable_start_string='{@', variable_end_string='@}')
-        self.native_env.filters['escape'] = CellParser.escape_string
-        self.native_env.filters['eval'] = CellParser.evaluate_string
+        self.env.filters["escape"] = CellParser.escape_string
+        self.env.filters["eval"] = CellParser.evaluate_string
+        self.native_env = NativeEnvironment(
+            variable_start_string="{@", variable_end_string="@}"
+        )
+        self.native_env.filters["escape"] = CellParser.escape_string
+        self.native_env.filters["eval"] = CellParser.evaluate_string
 
     def split_into_lists(self, string):
-        l1 = self.split_by_separator(string, '|')
+        l1 = self.split_by_separator(string, "|")
         if type(l1) == str:
-            output = self.split_by_separator(string, ';')
+            output = self.split_by_separator(string, ";")
         else:
-            output = [self.split_by_separator(s, ';') for s in l1]
+            output = [self.split_by_separator(s, ";") for s in l1]
         return self.cleanse(output)
 
     def cleanse(self, nested_list):
-        # Unescape escaped characters (\, |, ;) 
+        # Unescape escaped characters (\, |, ;)
         if type(nested_list) == str:
-            return nested_list.strip() \
-                              .replace('\\\\', '\1') \
-                              .replace('\\|', '|') \
-                              .replace('\\;', ';') \
-                              .replace('\1', '\\')
+            return (
+                nested_list.strip()
+                .replace("\\\\", "\1")
+                .replace("\\|", "|")
+                .replace("\\;", ";")
+                .replace("\1", "\\")
+            )
         else:
-            return [self.cleanse(l) for l in nested_list]        
+            return [self.cleanse(l) for l in nested_list]
 
     def split_by_separator(self, string, sep):
         pos = 0
         sep_locations = []
         while pos < len(string):
             c = string[pos]
-            if c == '\\':
+            if c == "\\":
                 pos += 1
             elif c == sep:
                 sep_locations.append(pos)
@@ -62,10 +66,13 @@ class CellParser:
             if len(string) - 1 in sep_locations:
                 # Special case: Last character is a separator.
                 # Here we don't put '' at the end of the list
-                locations = [-1] + sep_locations[:-1] + [len(string)-1]
+                locations = [-1] + sep_locations[:-1] + [len(string) - 1]
             else:
                 locations = [-1] + sep_locations + [len(string)]
-            return [string[locations[i]+1:locations[i+1]] for i in range(len(locations)-1)]
+            return [
+                string[locations[i] + 1 : locations[i + 1]]
+                for i in range(len(locations) - 1)
+            ]
 
     def parse(self, value, context={}):
         is_object = CellParser.BooleanWrapper()
@@ -83,19 +90,21 @@ class CellParser:
         # whether the parsing result represents an object that
         # is not to be processed any further.
         if value is None:
-            return ''
+            return ""
         value = str(value)
-        if context is None or (not context and '{' not in value):
+        if context is None or (not context and "{" not in value):
             # This is a hacky optimization.
             return value
         stripped_value = value.strip()
         env = self.env
-        if stripped_value.startswith('{@') and stripped_value.endswith('@}'):
+        if stripped_value.startswith("{@") and stripped_value.endswith("@}"):
             # Special case: Return a python object rather than a string,
             # if possible.
             # Ensure this is a single template, not e.g. '{@ x @} {@ y @}'
-            if not stripped_value[2:].find('{@') == -1:
-                LOGGER.critical(f'Cell may not contain nested "{{@" templates. Cell content: "{stripped_value}"')
+            if not stripped_value[2:].find("{@") == -1:
+                LOGGER.critical(
+                    f'Cell may not contain nested "{{@" templates. Cell content: "{stripped_value}"'
+                )
             if is_object is not None:
                 is_object.boolean = True
             env = self.native_env
@@ -104,4 +113,6 @@ class CellParser:
             template = env.from_string(stripped_value)
             return template.render(context)
         except Exception as e:
-            LOGGER.critical(f'Error while parsing cell "{stripped_value}" with context "{context}": {str(e)}')
+            LOGGER.critical(
+                f'Error while parsing cell "{stripped_value}" with context "{context}": {str(e)}'
+            )

--- a/src/rpft/parsers/common/rowdatasheet.py
+++ b/src/rpft/parsers/common/rowdatasheet.py
@@ -1,15 +1,16 @@
 import networkx as nx
 import tablib
+
 # from .sheetparser import SheetParser
 
-class RowDataSheet:
 
+class RowDataSheet:
     def __init__(self, row_parser, rows):
-        '''
+        """
         Args:
           rows: a list of RowModel instances
           row_parser: parser to use for converting rows to flat dicts.
-        '''
+        """
         self.row_parser = row_parser
         self.rows = rows
 
@@ -17,8 +18,8 @@ class RowDataSheet:
     #     sheet_parser = SheetParser(row_parser, context, filename, file_format)
     #     return sheet_parser.get_row_data_sheet()
 
-    def export(self, filename, file_format='csv'):
-        '''
+    def export(self, filename, file_format="csv"):
+        """
         Export a list of RowModel instances to file.
 
         Args:
@@ -26,30 +27,30 @@ class RowDataSheet:
             format: Export file format.
                 Supported file formats as supported by tablib,
                 see https://tablib.readthedocs.io/en/stable/formats.html
-        '''
+        """
         data = self.convert_to_tablib()
         exported_data = data.export(file_format)
-        write_type = 'w' if type(exported_data) == str else 'wb'
+        write_type = "w" if type(exported_data) == str else "wb"
         with open(filename, write_type) as f:
             f.write(exported_data)
 
     def convert_to_tablib(self):
-        '''
+        """
         Convert a list of RowModel instances to tablib.Dataset.
 
         Return:
           A tablib.Dataset representation of the data.
-        '''
+        """
 
         data = tablib.Dataset()
         data.headers = self._get_headers()
         for row in self.rows:
             row_dict = self.row_parser.unparse_row(row)
-            data.append([row_dict.get(header, '') for header in data.headers])
+            data.append([row_dict.get(header, "") for header in data.headers])
         return data
 
     def _get_headers(self):
-        '''
+        """
         Get an ordered list of column headers.
         Each row contains a subset of the final set of column headers.
         These subsets need to be merged while respecting the relative order
@@ -59,7 +60,7 @@ class RowDataSheet:
         to uniquely infer the order of the headers.
         Return:
             A list of strings representing the column headers of the sheet.
-        '''
+        """
 
         # Create a graph (representing a poset) whose nodes are the column headers,
         # and whose edges A -> B represent that column header A should come before

--- a/src/rpft/parsers/common/sheetparser.py
+++ b/src/rpft/parsers/common/sheetparser.py
@@ -6,21 +6,20 @@ LOGGER = get_logger()
 
 
 class SheetParser:
-
     def __init__(self, row_parser, table, context={}):
-        '''
+        """
         Args:
             row_parser: parser to convert flat dicts to RowModel instances.
             context: context used for template parsing
             table: Tablib Dataset representing the table to be parsed.
-        '''
+        """
 
         self.row_parser = row_parser
         self.bookmarks = {}
         self.input_rows = []
         for row_idx, row in enumerate(table):
-            row_dict = {h : e for h, e in zip(table.headers, row)}
-            self.input_rows.append((row_dict, row_idx+2))
+            row_dict = {h: e for h, e in zip(table.headers, row)}
+            self.input_rows.append((row_dict, row_idx + 2))
         self.iterator = iter(self.input_rows)
         self.context = copy.deepcopy(context)
 

--- a/src/rpft/parsers/creation/campaigneventrowmodel.py
+++ b/src/rpft/parsers/creation/campaigneventrowmodel.py
@@ -3,31 +3,33 @@ from pydantic import validator
 
 
 class CampaignEventRowModel(ParserModel):
-    uuid: str = ''
+    uuid: str = ""
     offset: str
     unit: str
     event_type: str
-    delivery_hour: str = ''
-    message: str = ''
+    delivery_hour: str = ""
+    message: str = ""
     relative_to: str
     start_mode: str
-    flow: str = ''
-    base_language: str = ''
+    flow: str = ""
+    base_language: str = ""
 
-    @validator('unit')
+    @validator("unit")
     def validate_unit(cls, v):
-        if v not in ['M', 'H', 'D', 'W']:
-            raise ValueError('unit must be M (minute), H (hour), D (day) or W (week)')
+        if v not in ["M", "H", "D", "W"]:
+            raise ValueError("unit must be M (minute), H (hour), D (day) or W (week)")
         return v
 
-    @validator('start_mode')
+    @validator("start_mode")
     def validate_start_mode(cls, v):
-        if v not in ['I', 'S', 'P']:
-            raise ValueError("start_mode must be I (interrupt current flow), S (skip event if in flow) or P (send message and don't affect flow)")
+        if v not in ["I", "S", "P"]:
+            raise ValueError(
+                "start_mode must be I (interrupt current flow), S (skip event if in flow) or P (send message and don't affect flow)"
+            )
         return v
 
-    @validator('event_type')
+    @validator("event_type")
     def validate_event_type(cls, v):
-        if v not in ['M', 'F']:
-            raise ValueError('event_type must be F (flow) or M (message)')
+        if v not in ["M", "F"]:
+            raise ValueError("event_type must be F (flow) or M (message)")
         return v

--- a/src/rpft/parsers/creation/campaignparser.py
+++ b/src/rpft/parsers/creation/campaignparser.py
@@ -5,27 +5,34 @@ LOGGER = get_logger()
 
 
 class CampaignParser:
-	def __init__(self, name, group_name, rows):
-		self.campaign = Campaign(name, group_name=group_name)
-		self.rows = rows
+    def __init__(self, name, group_name, rows):
+        self.campaign = Campaign(name, group_name=group_name)
+        self.rows = rows
 
-	def parse(self):
-		for row_idx, row in enumerate(self.rows):
-			with logging_context(f"row {row_idx+2}"):
-				message = None
-				base_language = None
-				if row.message:
-					message = {"eng" : row.message}
-					base_language = row.base_language or "eng"
-				delivery_hour = -1
-				if row.delivery_hour:
-					delivery_hour = int(row.delivery_hour)
-				try:
-					event = CampaignEvent(
-							int(row.offset), row.unit, row.event_type, delivery_hour, row.start_mode,
-							relative_to_label=row.relative_to, flow_name=row.flow or None,
-							message=message, base_language=base_language)
-					self.campaign.add_event(event)
-				except ValueError as e:
-					LOGGER.critical(str(e))
-		return self.campaign
+    def parse(self):
+        for row_idx, row in enumerate(self.rows):
+            with logging_context(f"row {row_idx+2}"):
+                message = None
+                base_language = None
+                if row.message:
+                    message = {"eng": row.message}
+                    base_language = row.base_language or "eng"
+                delivery_hour = -1
+                if row.delivery_hour:
+                    delivery_hour = int(row.delivery_hour)
+                try:
+                    event = CampaignEvent(
+                        int(row.offset),
+                        row.unit,
+                        row.event_type,
+                        delivery_hour,
+                        row.start_mode,
+                        relative_to_label=row.relative_to,
+                        flow_name=row.flow or None,
+                        message=message,
+                        base_language=base_language,
+                    )
+                    self.campaign.add_event(event)
+                except ValueError as e:
+                    LOGGER.critical(str(e))
+        return self.campaign

--- a/src/rpft/parsers/creation/constants.py
+++ b/src/rpft/parsers/creation/constants.py
@@ -1,8 +1,5 @@
 from collections import defaultdict
 
-excel_to_json_type_map = {
-    'send_message': 'send_msg',
-    'go_to': 'go_to'
-}
+excel_to_json_type_map = {"send_message": "send_msg", "go_to": "go_to"}
 
 nodes_map = defaultdict()

--- a/src/rpft/parsers/creation/contentindexparser.py
+++ b/src/rpft/parsers/creation/contentindexparser.py
@@ -16,192 +16,270 @@ LOGGER = get_logger()
 
 
 class TemplateSheet:
-	def __init__(self, table, argument_definitions):
-		self.table = table
-		self.argument_definitions = argument_definitions
+    def __init__(self, table, argument_definitions):
+        self.table = table
+        self.argument_definitions = argument_definitions
 
 
 class ContentIndexParser:
+    def __init__(
+        self,
+        sheet_reader=None,
+        user_data_model_module_name=None,
+        tag_matcher=TagMatcher(),
+    ):
+        self.tag_matcher = tag_matcher
+        self.template_sheets = {}  # values: tablib tables
+        self.data_sheets = {}  # values: OrderedDicts of RowModels
+        self.flow_definition_rows = []  # list of ContentIndexRowModel
+        self.campaign_parsers = []  # list of CampaignParser
+        if user_data_model_module_name:
+            self.user_models_module = importlib.import_module(
+                user_data_model_module_name
+            )
+        if sheet_reader:
+            self.add_content_index(sheet_reader)
 
-	def  __init__(self, sheet_reader=None, user_data_model_module_name=None, tag_matcher=TagMatcher()):
-		self.tag_matcher = tag_matcher
-		self.template_sheets = {}  # values: tablib tables
-		self.data_sheets = {}  # values: OrderedDicts of RowModels
-		self.flow_definition_rows = []  # list of ContentIndexRowModel
-		self.campaign_parsers = []  # list of CampaignParser
-		if user_data_model_module_name:
-			self.user_models_module = importlib.import_module(user_data_model_module_name)
-		if sheet_reader:
-			self.add_content_index(sheet_reader)
+    def add_content_index(self, sheet_reader):
+        main_sheet = sheet_reader.get_main_sheet()
+        self.process_content_index_table(sheet_reader, main_sheet, "content_index")
 
-	def add_content_index(self, sheet_reader):
-		main_sheet = sheet_reader.get_main_sheet()
-		self.process_content_index_table(sheet_reader, main_sheet, "content_index")
+    def process_content_index_table(
+        self, sheet_reader, content_index_table, content_index_name
+    ):
+        # content_index_table is in tablib table format
+        row_parser = RowParser(ContentIndexRowModel, CellParser())
+        sheet_parser = SheetParser(row_parser, content_index_table)
+        content_index_rows = sheet_parser.parse_all()
+        for row_idx, row in enumerate(content_index_rows):
+            logging_prefix = f"{content_index_name} | row {row_idx+2}"
+            with logging_context(logging_prefix):
+                if row.status == "draft":
+                    continue
+                if not self.tag_matcher.matches(row.tags):
+                    continue
+                if row.type == "content_index":
+                    if not len(row.sheet_name) == 1:
+                        LOGGER.critical(
+                            "For content_index rows, exactly one sheet_name has to be specified"
+                        )
+                    sheet_name = row.sheet_name[0]
+                    sheet = sheet_reader.get_sheet(sheet_name)
+                    with logging_context(f"{sheet_name}"):
+                        self.process_content_index_table(
+                            sheet_reader, sheet, sheet_name
+                        )
+                elif row.type == "data_sheet":
+                    if not len(row.sheet_name) >= 1:
+                        LOGGER.critical(
+                            "For data_sheet rows, at least one sheet_name has to be specified"
+                        )
+                    self.process_data_sheet(
+                        sheet_reader, row.sheet_name, row.new_name, row.data_model
+                    )
+                elif row.type in ["template_definition", "create_flow"]:
+                    if not len(row.sheet_name) == 1:
+                        LOGGER.critical(
+                            "For template_definition/create_flow rows, exactly one sheet_name has to be specified"
+                        )
+                    sheet_name = row.sheet_name[0]
+                    if sheet_name not in self.template_sheets:
+                        sheet = sheet_reader.get_sheet(sheet_name)
+                        self.template_sheets[sheet_name] = TemplateSheet(
+                            sheet, row.template_argument_definitions
+                        )
+                    if row.type == "create_flow":
+                        self.flow_definition_rows.append((logging_prefix, row))
+                elif row.type == "create_campaign":
+                    if not len(row.sheet_name) == 1:
+                        LOGGER.critical(
+                            "For create_campaign rows, exactly one sheet_name has to be specified"
+                        )
+                    campaign_parser = self.create_campaign_parser(sheet_reader, row)
+                    self.campaign_parsers.append((logging_prefix, campaign_parser))
+                else:
+                    LOGGER.error(f'invalid type: "{row.type}"')
 
-	def process_content_index_table(self, sheet_reader, content_index_table, content_index_name):
-		# content_index_table is in tablib table format
-		row_parser = RowParser(ContentIndexRowModel, CellParser())
-		sheet_parser = SheetParser(row_parser, content_index_table)
-		content_index_rows = sheet_parser.parse_all()
-		for row_idx, row in enumerate(content_index_rows):
-			logging_prefix = f"{content_index_name} | row {row_idx+2}"
-			with logging_context(logging_prefix):
-				if row.status == 'draft':
-					continue
-				if not self.tag_matcher.matches(row.tags):
-					continue
-				if row.type == 'content_index':
-					if not len(row.sheet_name) == 1:
-						LOGGER.critical('For content_index rows, exactly one sheet_name has to be specified')
-					sheet_name = row.sheet_name[0]
-					sheet = sheet_reader.get_sheet(sheet_name)
-					with logging_context(f"{sheet_name}"):
-						self.process_content_index_table(sheet_reader, sheet, sheet_name)
-				elif row.type == 'data_sheet':
-					if not len(row.sheet_name) >= 1:
-						LOGGER.critical('For data_sheet rows, at least one sheet_name has to be specified')
-					self.process_data_sheet(sheet_reader, row.sheet_name, row.new_name, row.data_model)
-				elif row.type in ['template_definition', 'create_flow']:
-					if not len(row.sheet_name) == 1:
-						LOGGER.critical('For template_definition/create_flow rows, exactly one sheet_name has to be specified')
-					sheet_name = row.sheet_name[0]
-					if sheet_name not in self.template_sheets:
-						sheet = sheet_reader.get_sheet(sheet_name)
-						self.template_sheets[sheet_name] = TemplateSheet(sheet, row.template_argument_definitions)
-					if row.type == 'create_flow':
-						self.flow_definition_rows.append((logging_prefix, row))
-				elif row.type == 'create_campaign':
-					if not len(row.sheet_name) == 1:
-						LOGGER.critical('For create_campaign rows, exactly one sheet_name has to be specified')
-					campaign_parser = self.create_campaign_parser(sheet_reader, row)
-					self.campaign_parsers.append((logging_prefix, campaign_parser))
-				else:
-					LOGGER.error(f'invalid type: "{row.type}"')
+    def process_data_sheet(self, sheet_reader, sheet_names, new_name, data_model_name):
+        if not hasattr(self, "user_models_module"):
+            LOGGER.critical(
+                "If there are data sheets, a user_data_model_module_name has to be provided (as commandline argument)"
+            )
+            return
+        if not data_model_name:
+            LOGGER.critical("No data_model_name provided for data sheet.")
+            return
+        if len(sheet_names) > 1 and not new_name:
+            LOGGER.critical(
+                "If multiple sheets are concatenated, a new_name has to be provided"
+            )
+            return
+        if not new_name:
+            new_name = sheet_names[0]
+        content = OrderedDict()
+        for sheet_name in sheet_names:
+            with logging_context(sheet_name):
+                data_table = sheet_reader.get_sheet(sheet_name)
+                try:
+                    user_model = getattr(self.user_models_module, data_model_name)
+                except AttributeError:
+                    LOGGER.critical(
+                        f'Undefined data_model_name "{data_model_name}" in {self.user_models_module}.'
+                    )
+                    return
+                row_parser = RowParser(user_model, CellParser())
+                sheet_parser = SheetParser(row_parser, data_table)
+                data_rows = sheet_parser.parse_all()
+                sheet_content = OrderedDict((row.ID, row) for row in data_rows)
+                content.update(sheet_content)
+        self.data_sheets[new_name] = content
 
-	def process_data_sheet(self, sheet_reader, sheet_names, new_name, data_model_name):
-		if not hasattr(self, 'user_models_module'):
-			LOGGER.critical('If there are data sheets, a user_data_model_module_name has to be provided (as commandline argument)')
-			return
-		if not data_model_name:
-			LOGGER.critical('No data_model_name provided for data sheet.')
-			return
-		if len(sheet_names) > 1 and not new_name:
-			LOGGER.critical('If multiple sheets are concatenated, a new_name has to be provided')
-			return
-		if not new_name:
-			new_name = sheet_names[0]
-		content = OrderedDict()
-		for sheet_name in sheet_names:
-			with logging_context(sheet_name):
-				data_table = sheet_reader.get_sheet(sheet_name)
-				try:
-					user_model = getattr(self.user_models_module, data_model_name)
-				except AttributeError:
-					LOGGER.critical(f'Undefined data_model_name "{data_model_name}" in {self.user_models_module}.')
-					return
-				row_parser = RowParser(user_model, CellParser())
-				sheet_parser = SheetParser(row_parser, data_table)
-				data_rows = sheet_parser.parse_all()
-				sheet_content = OrderedDict((row.ID, row) for row in data_rows)
-				content.update(sheet_content)
-		self.data_sheets[new_name] = content
+    def get_data_model_instance(self, sheet_name, row_id):
+        return self.data_sheets[sheet_name][row_id]
 
-	def get_data_model_instance(self, sheet_name, row_id):
-		return self.data_sheets[sheet_name][row_id]
+    def get_all_data_model_instances(self, sheet_name):
+        return self.data_sheets[sheet_name]
 
-	def get_all_data_model_instances(self, sheet_name):
-		return self.data_sheets[sheet_name]
+    def get_template_sheet(self, name):
+        return self.template_sheets[name]
 
-	def get_template_sheet(self, name):
-		return self.template_sheets[name]
+    def get_node_group(
+        self, template_name, data_sheet, data_row_id, template_arguments
+    ):
+        if (data_sheet and data_row_id) or (not data_sheet and not data_row_id):
+            flow_name = template_name
+            with logging_context(f"{template_name}"):
+                return self.parse_flow(
+                    template_name,
+                    data_sheet,
+                    data_row_id,
+                    template_arguments,
+                    RapidProContainer(),
+                    parse_as_block=True,
+                )
+        else:
+            LOGGER.critical(
+                "For insert_as_block, either both data_sheet and data_row_id or neither have to be provided."
+            )
 
-	def get_node_group(self, template_name, data_sheet, data_row_id, template_arguments):
-		if (data_sheet and data_row_id) or (not data_sheet and not data_row_id):
-			flow_name = template_name
-			with logging_context(f'{template_name}'):
-				return self.parse_flow(template_name, data_sheet, data_row_id, template_arguments, RapidProContainer(), parse_as_block=True)
-		else:
-			LOGGER.critical('For insert_as_block, either both data_sheet and data_row_id or neither have to be provided.')
+    def parse_all(self):
+        rapidpro_container = RapidProContainer()
+        self.parse_all_flows(rapidpro_container)
+        self.parse_all_campaigns(rapidpro_container)
+        return rapidpro_container
 
-	def parse_all(self):
-		rapidpro_container = RapidProContainer()
-		self.parse_all_flows(rapidpro_container)
-		self.parse_all_campaigns(rapidpro_container)
-		return rapidpro_container
+    def create_campaign_parser(self, sheet_reader, row):
+        sheet_name = row.sheet_name[0]
+        sheet = sheet_reader.get_sheet(sheet_name)
+        row_parser = RowParser(CampaignEventRowModel, CellParser())
+        sheet_parser = SheetParser(row_parser, sheet)
+        rows = sheet_parser.parse_all()
+        return CampaignParser(row.new_name or sheet_name, row.group, rows)
 
-	def create_campaign_parser(self, sheet_reader, row):
-		sheet_name = row.sheet_name[0]
-		sheet = sheet_reader.get_sheet(sheet_name)
-		row_parser = RowParser(CampaignEventRowModel, CellParser())
-		sheet_parser = SheetParser(row_parser, sheet)
-		rows = sheet_parser.parse_all()
-		return CampaignParser(row.new_name or sheet_name, row.group, rows)
+    def parse_all_campaigns(self, rapidpro_container):
+        for logging_prefix, campaign_parser in self.campaign_parsers:
+            sheet_name = campaign_parser.campaign.name
+            with logging_context(f"{logging_prefix} | {sheet_name}"):
+                campaign = campaign_parser.parse()
+                rapidpro_container.add_campaign(campaign)
 
-	def parse_all_campaigns(self, rapidpro_container):
-		for logging_prefix, campaign_parser in self.campaign_parsers:
-			sheet_name = campaign_parser.campaign.name
-			with logging_context(f'{logging_prefix} | {sheet_name}'):
-				campaign = campaign_parser.parse()
-				rapidpro_container.add_campaign(campaign)
+    def parse_all_flows(self, rapidpro_container):
+        for logging_prefix, row in self.flow_definition_rows:
+            with logging_context(f"{logging_prefix} | {row.sheet_name[0]}"):
+                if row.data_sheet and not row.data_row_id:
+                    data_rows = self.get_all_data_model_instances(row.data_sheet)
+                    for data_row_id in data_rows.keys():
+                        with logging_context(f'with data_row_id "{data_row_id}"'):
+                            self.parse_flow(
+                                row.sheet_name[0],
+                                row.data_sheet,
+                                data_row_id,
+                                row.template_arguments,
+                                rapidpro_container,
+                                row.new_name,
+                            )
+                elif not row.data_sheet and row.data_row_id:
+                    LOGGER.critical(
+                        "For create_flow, if data_row_id is provided, data_sheet must also be provided."
+                    )
+                else:
+                    self.parse_flow(
+                        row.sheet_name[0],
+                        row.data_sheet,
+                        row.data_row_id,
+                        row.template_arguments,
+                        rapidpro_container,
+                        row.new_name,
+                    )
 
-	def parse_all_flows(self, rapidpro_container):
-		for logging_prefix, row in self.flow_definition_rows:
-			with logging_context(f'{logging_prefix} | {row.sheet_name[0]}'):
-				if row.data_sheet and not row.data_row_id:
-					data_rows = self.get_all_data_model_instances(row.data_sheet)
-					for data_row_id in data_rows.keys():
-						with logging_context(f'with data_row_id "{data_row_id}"'):
-							self.parse_flow(row.sheet_name[0], row.data_sheet, data_row_id, row.template_arguments, rapidpro_container, row.new_name)
-				elif not row.data_sheet and row.data_row_id:
-					LOGGER.critical('For create_flow, if data_row_id is provided, data_sheet must also be provided.')
-				else:
-					self.parse_flow(row.sheet_name[0], row.data_sheet, row.data_row_id, row.template_arguments, rapidpro_container, row.new_name)	
+    def parse_flow(
+        self,
+        sheet_name,
+        data_sheet,
+        data_row_id,
+        template_arguments,
+        rapidpro_container,
+        new_name="",
+        parse_as_block=False,
+    ):
+        base_name = new_name or sheet_name
+        if data_sheet and data_row_id:
+            flow_name = " - ".join([base_name, data_row_id])
+            context = self.get_data_model_instance(data_sheet, data_row_id)
+        else:
+            if data_sheet or data_row_id:
+                LOGGER.warn(
+                    "For create_flow, if no data_sheet is provided, data_row_id should be blank as well."
+                )
+            flow_name = base_name
+            context = {}
+        template_sheet = self.get_template_sheet(sheet_name)
+        template_table = template_sheet.table
+        template_argument_definitions = template_sheet.argument_definitions
+        context = dict(context)
+        self.map_template_arguments_to_context(
+            template_argument_definitions, template_arguments, context
+        )
+        flow_parser = FlowParser(
+            rapidpro_container,
+            flow_name,
+            template_table,
+            context=context,
+            content_index_parser=self,
+        )
+        if parse_as_block:
+            return flow_parser.parse_as_block()
+        else:
+            return flow_parser.parse()
+        # Is automatically added to the rapidpro_container, for now.
 
-	def parse_flow(self, sheet_name, data_sheet, data_row_id, template_arguments, rapidpro_container, new_name='', parse_as_block=False):
-		base_name = new_name or sheet_name
-		if data_sheet and data_row_id:
-			flow_name = ' - '.join([base_name, data_row_id])
-			context = self.get_data_model_instance(data_sheet, data_row_id)
-		else:
-			if data_sheet or data_row_id:
-				LOGGER.warn('For create_flow, if no data_sheet is provided, data_row_id should be blank as well.')
-			flow_name = base_name
-			context = {}
-		template_sheet = self.get_template_sheet(sheet_name)
-		template_table = template_sheet.table
-		template_argument_definitions = template_sheet.argument_definitions
-		context = dict(context)
-		self.map_template_arguments_to_context(template_argument_definitions, template_arguments, context)
-		flow_parser = FlowParser(rapidpro_container, flow_name, template_table, context=context, content_index_parser=self)
-		if parse_as_block:
-			return flow_parser.parse_as_block()
-		else:
-			return flow_parser.parse()
-		# Is automatically added to the rapidpro_container, for now.
-
-	def map_template_arguments_to_context(self, arg_defs, args, context):
-		# Template arguments are positional arguments.
-		# This function maps them to the arguments from the template
-		# definition, and adds the values of the arguments to the context
-		# with the appropriate variable name (from the definition)
-		if len(args) > len(arg_defs):
-			# Check if these args are non-empty.
-			# Once the row parser is cleaned up to eliminate trailing ''
-			# entries, this won't be necessary
-			extra_args = args[len(arg_defs):]
-			non_empty_extra_args = [ea for ea in extra_args if ea]
-			if non_empty_extra_args:
-				LOGGER.warn('Too many arguments provided to template')
-			# All extra args are blank. Truncate them
-			args = args[:len(arg_defs)]
-		args_padding = [''] * (len(arg_defs) - len(args))
-		for arg_def, arg in zip(arg_defs, args + args_padding):
-			if arg_def.name in context:
-				LOGGER.critical(f'Template argument "{arg_def.name}" doubly defined in context: "{context}"')
-			arg_value = arg if arg != '' else arg_def.default_value
-			if arg_value == '':
-				LOGGER.critical(f'Required template argument "{arg_def.name}" not provided')
-			if arg_def.type == 'sheet':
-				context[arg_def.name] = self.data_sheets[arg_value]
-			else:
-				context[arg_def.name] = arg_value
+    def map_template_arguments_to_context(self, arg_defs, args, context):
+        # Template arguments are positional arguments.
+        # This function maps them to the arguments from the template
+        # definition, and adds the values of the arguments to the context
+        # with the appropriate variable name (from the definition)
+        if len(args) > len(arg_defs):
+            # Check if these args are non-empty.
+            # Once the row parser is cleaned up to eliminate trailing ''
+            # entries, this won't be necessary
+            extra_args = args[len(arg_defs) :]
+            non_empty_extra_args = [ea for ea in extra_args if ea]
+            if non_empty_extra_args:
+                LOGGER.warn("Too many arguments provided to template")
+            # All extra args are blank. Truncate them
+            args = args[: len(arg_defs)]
+        args_padding = [""] * (len(arg_defs) - len(args))
+        for arg_def, arg in zip(arg_defs, args + args_padding):
+            if arg_def.name in context:
+                LOGGER.critical(
+                    f'Template argument "{arg_def.name}" doubly defined in context: "{context}"'
+                )
+            arg_value = arg if arg != "" else arg_def.default_value
+            if arg_value == "":
+                LOGGER.critical(
+                    f'Required template argument "{arg_def.name}" not provided'
+                )
+            if arg_def.type == "sheet":
+                context[arg_def.name] = self.data_sheets[arg_value]
+            else:
+                context[arg_def.name] = arg_value

--- a/src/rpft/parsers/creation/contentindexrowmodel.py
+++ b/src/rpft/parsers/creation/contentindexrowmodel.py
@@ -1,22 +1,24 @@
 from rpft.parsers.common.rowparser import ParserModel
 from typing import List
 
+
 class TemplateArgument(ParserModel):
     name: str
-    type: str = ''
-    default_value: str = ''
+    type: str = ""
+    default_value: str = ""
+
 
 class ContentIndexRowModel(ParserModel):
-    type: str = ''
-    new_name: str = ''
+    type: str = ""
+    new_name: str = ""
     sheet_name: List[str] = []
-    data_sheet: str = ''
-    data_row_id: str = ''
+    data_sheet: str = ""
+    data_row_id: str = ""
     template_argument_definitions: List[TemplateArgument] = []  # internal name
     template_arguments: list = []
-    data_model: str = ''
-    group: str = ''
-    status: str = ''
+    data_model: str = ""
+    group: str = ""
+    status: str = ""
     tags: List[str] = []
 
     def field_name_to_header_name(field):
@@ -26,7 +28,7 @@ class ContentIndexRowModel(ParserModel):
             return header
 
     def header_name_to_field_name_with_context(header, row):
-        if row["type"] == 'template_definition' and header == "template_arguments":
+        if row["type"] == "template_definition" and header == "template_arguments":
             return "template_argument_definitions"
         else:
             return header

--- a/src/rpft/parsers/creation/datarowmodel.py
+++ b/src/rpft/parsers/creation/datarowmodel.py
@@ -1,4 +1,5 @@
 from rpft.parsers.common.rowparser import ParserModel
 
+
 class DataRowModel(ParserModel):
-	ID : str = ''
+    ID: str = ""

--- a/src/rpft/parsers/creation/flowparser.py
+++ b/src/rpft/parsers/creation/flowparser.py
@@ -1,12 +1,23 @@
 from collections import defaultdict
 
 from rpft.rapidpro.models.actions import (
-    SendMessageAction, SetContactFieldAction, AddContactGroupAction,
-    RemoveContactGroupAction, SetRunResultAction, SetContactPropertyAction,
-    Group, WhatsAppMessageTemplating)
+    SendMessageAction,
+    SetContactFieldAction,
+    AddContactGroupAction,
+    RemoveContactGroupAction,
+    SetRunResultAction,
+    SetContactPropertyAction,
+    Group,
+    WhatsAppMessageTemplating,
+)
 from rpft.rapidpro.models.containers import FlowContainer
 from rpft.rapidpro.models.exceptions import RapidProActionError
-from rpft.rapidpro.models.nodes import BasicNode, SwitchRouterNode, RandomRouterNode, EnterFlowNode
+from rpft.rapidpro.models.nodes import (
+    BasicNode,
+    SwitchRouterNode,
+    RandomRouterNode,
+    EnterFlowNode,
+)
 from rpft.rapidpro.models.routers import SwitchRouter
 from rpft.parsers.common.cellparser import CellParser
 from rpft.parsers.common.sheetparser import SheetParser
@@ -46,9 +57,9 @@ class NodeGroup:
 
     def add_exit(self, destination_uuid, condition):
         if condition != Condition():
-            LOGGER.critical('Cannot attach conditional edges to a block.')
+            LOGGER.critical("Cannot attach conditional edges to a block.")
         if not self.has_loose_exits():
-            LOGGER.critical('Block has no loose exit to connect to.')
+            LOGGER.critical("Block has no loose exit to connect to.")
         for node_group in self.node_groups:
             if node_group.has_loose_exits():
                 node_group.connect_loose_exits(destination_uuid)
@@ -98,10 +109,12 @@ class NoOpNodeGroup:
                 edge.source_node_group.connect_loose_exits(destination_uuid)
 
     def entry_node(self):
-        LOGGER.critical("NotImplementedError: go_to not implemented to link to no_op row.")
+        LOGGER.critical(
+            "NotImplementedError: go_to not implemented to link to no_op row."
+        )
 
     def add_parent_edge(self, source_node_group, condition):
-        self.parent_edges.append(NoOpNodeGroup.ParentEdge(source_node_group,condition))
+        self.parent_edges.append(NoOpNodeGroup.ParentEdge(source_node_group, condition))
         if self.router_node is not None:
             source_node_group.add_exit(self.router_node.uuid, condition)
 
@@ -113,12 +126,14 @@ class NoOpNodeGroup:
                 return
             else:
                 if not condition.variable:
-                    LOGGER.critical('Condition must have a variable.')
+                    LOGGER.critical("Condition must have a variable.")
                 self.router_node = SwitchRouterNode(condition.variable)
                 self.child_node_ref = None
                 for edge in self.parent_edges:
                     # Update all the parent exits
-                    edge.source_node_group.add_exit(self.router_node.uuid, edge.condition)
+                    edge.source_node_group.add_exit(
+                        self.router_node.uuid, edge.condition
+                    )
 
         # We now have a router_node
         # TODO: Code duplication here, especially with respect to default values.
@@ -128,11 +143,11 @@ class NoOpNodeGroup:
         else:
             self.router_node.add_choice(
                 comparison_variable=condition.variable,
-                comparison_type=condition.type or 'has_any_word',
+                comparison_type=condition.type or "has_any_word",
                 comparison_arguments=[condition.value],
                 category_name=condition.name,
                 destination_uuid=destination_uuid,
-                is_default=False
+                is_default=False,
             )
 
     def add_nodes_to_flow(self, flow_container):
@@ -146,7 +161,7 @@ class RowNodeGroup:
     # (which may have multiple conditional exits)
 
     def __init__(self, node, row_type):
-        '''node: first node in the group'''
+        """node: first node in the group"""
         self.nodes = [node]
         self.row_type = row_type
 
@@ -187,32 +202,39 @@ class RowNodeGroup:
 
         # Completed/Expired edge from start_new_flow
         if isinstance(exit_node, EnterFlowNode):
-            if condition.value.lower() in ['complete', 'completed']:
+            if condition.value.lower() in ["complete", "completed"]:
                 exit_node.update_completed_exit(destination_uuid)
                 self.has_loose_exit = False
-            elif condition.value.lower() == 'expired':
+            elif condition.value.lower() == "expired":
                 exit_node.update_expired_exit(destination_uuid)
             else:
-                LOGGER.error("Condition from start_new_flow must be 'Completed' or 'Expired'.")
+                LOGGER.error(
+                    "Condition from start_new_flow must be 'Completed' or 'Expired'."
+                )
             return
 
         # No Response edge from wait_for_response
-        if isinstance(exit_node, SwitchRouterNode) and condition.value.lower() == "no response":
+        if (
+            isinstance(exit_node, SwitchRouterNode)
+            and condition.value.lower() == "no response"
+        ):
             if exit_node.has_positive_wait():
                 exit_node.update_no_response_exit(destination_uuid)
             else:
-                LOGGER.warn("No Response exit only exists for wait_for_response rows with non-zero timeout.")
+                LOGGER.warn(
+                    "No Response exit only exists for wait_for_response rows with non-zero timeout."
+                )
             return
 
         # We have a non-trivial condition. Fill in default values if necessary
         condition_type = condition.type
-        comparison_arguments=[condition.value]
+        comparison_arguments = [condition.value]
         wait_timeout = None
-        if self.row_type in ['split_by_group', 'split_by_value']:
+        if self.row_type in ["split_by_group", "split_by_value"]:
             variable = exit_node.router.operand
-            if self.row_type == 'split_by_group':
+            if self.row_type == "split_by_group":
                 # Should such defaults be initialized as part of the data model?
-                condition_type = 'has_group'
+                condition_type = "has_group"
                 # TODO: Validation step that fills in group/flow uuids
                 comparison_arguments = [None, condition.value]
         elif condition.variable:
@@ -220,7 +242,7 @@ class RowNodeGroup:
         else:
             # TODO: Check if the source node has a save_name, and use that instead?
             wait_timeout = 0
-            variable = '@input.text'
+            variable = "@input.text"
 
         if isinstance(exit_node, BasicNode):
             # We have a basic node, but a non-trivial condition.
@@ -236,24 +258,32 @@ class RowNodeGroup:
         if isinstance(exit_node.router, SwitchRouter):
             exit_node.add_choice(
                 comparison_variable=variable,
-                comparison_type=condition_type or 'has_any_word',
+                comparison_type=condition_type or "has_any_word",
                 comparison_arguments=comparison_arguments,
                 category_name=condition.name,
                 destination_uuid=destination_uuid,
-                is_default=False
+                is_default=False,
             )
         else:  # Random router
             # TODO: If a value is provided, respect the ordering provided there
             exit_node.add_choice(
                 category_name=condition.name or condition.value,
-                destination_uuid=destination_uuid
+                destination_uuid=destination_uuid,
             )
 
 
 class FlowParser:
-
-    def __init__(self, rapidpro_container, flow_name, table=None, flow_uuid=None, context=None, sheet_parser=None, content_index_parser=None):
-        '''
+    def __init__(
+        self,
+        rapidpro_container,
+        flow_name,
+        table=None,
+        flow_uuid=None,
+        context=None,
+        sheet_parser=None,
+        content_index_parser=None,
+    ):
+        """
         rapidpro_container: The parent RapidProContainer to contain the flow generated by this parser.
         flow_name: Name to be given to the flow.
         table: tablib.Dataset: The sheet rows generating the flow;
@@ -264,7 +294,7 @@ class FlowParser:
             note that a SheetParser contains a table by iself, and if this argument is provided,
             the table argument is ignored.
         content_index_parser: Required if there are insert_as_block rows.
-        '''
+        """
 
         self.rapidpro_container = rapidpro_container
         self.flow_name = flow_name
@@ -301,7 +331,7 @@ class FlowParser:
     def parse_as_block(self):
         self._parse_block()
         if not len(self.node_group_stack) == 1:
-            LOGGER.critical('Unexpected end of flow. Did you forget end_for/end_block?')
+            LOGGER.critical("Unexpected end of flow. Did you forget end_for/end_block?")
         return self.current_node_group()
 
     def parse(self):
@@ -310,21 +340,23 @@ class FlowParser:
         self.rapidpro_container.add_flow(flow_container)
         return flow_container
 
-    def _parse_block(self, depth=0, block_type='root_block', omit_content=False):
-        row, row_idx = self.sheet_parser.parse_next_row(omit_templating=omit_content, return_index=True)
+    def _parse_block(self, depth=0, block_type="root_block", omit_content=False):
+        row, row_idx = self.sheet_parser.parse_next_row(
+            omit_templating=omit_content, return_index=True
+        )
         while not self._is_end_of_block(block_type, row):
             if omit_content or not row.include_if:
-                if row.type == 'begin_for':
-                    self._parse_block(depth+1, 'for', omit_content=True)
-                elif row.type == 'begin_block':
-                    self._parse_block(depth+1, 'block', omit_content=True)
+                if row.type == "begin_for":
+                    self._parse_block(depth + 1, "for", omit_content=True)
+                elif row.type == "begin_block":
+                    self._parse_block(depth + 1, "block", omit_content=True)
             else:
-                if row.type == 'begin_for':
+                if row.type == "begin_for":
                     if len(row.loop_variable) >= 1 and row.loop_variable[0]:
                         iteration_variable = row.loop_variable[0]
                     else:
-                        with logging_context(f'row {row_idx}'):
-                            LOGGER.critical('begin_for must have a loop_variable')
+                        with logging_context(f"row {row_idx}"):
+                            LOGGER.critical("begin_for must have a loop_variable")
                     index_variable = None
                     if len(row.loop_variable) >= 2 and row.loop_variable[1]:
                         index_variable = row.loop_variable[1]
@@ -339,48 +371,59 @@ class FlowParser:
                         self.sheet_parser.add_to_context(iteration_variable, entry)
                         if index_variable:
                             self.sheet_parser.add_to_context(index_variable, i)
-                        self._parse_block(depth+1, 'for')
+                        self._parse_block(depth + 1, "for")
                     self.node_group_stack.pop()
                     self.append_node_group(new_node_group, row.row_id)
                     self.sheet_parser.remove_from_context(iteration_variable)
                     if index_variable:
                         self.sheet_parser.remove_from_context(index_variable)
                     self.sheet_parser.remove_bookmark(str(depth))
-                elif row.type == 'begin_block':
+                elif row.type == "begin_block":
                     new_node_group = NodeGroup()
                     self.node_group_stack.append(new_node_group)
                     # Interpret the row like a no-op to get the edges
                     if not row.is_starting_row():
                         self._parse_noop_row(row, store_row_id=False)
-                    self._parse_block(depth+1, 'block')
+                    self._parse_block(depth + 1, "block")
                     self.node_group_stack.pop()
                     self.append_node_group(new_node_group, row.row_id)
                 else:
-                    with logging_context(f'row {row_idx}'):
+                    with logging_context(f"row {row_idx}"):
                         self._parse_row(row)
-            row, row_idx = self.sheet_parser.parse_next_row(omit_templating=omit_content, return_index=True)
+            row, row_idx = self.sheet_parser.parse_next_row(
+                omit_templating=omit_content, return_index=True
+            )
 
     def _is_end_of_block(self, block_type, row):
         block_end_map = {
-            'end_for' : 'for',
-            'end_block' : 'block',
+            "end_for": "for",
+            "end_block": "block",
         }
         if row is None:
-            if block_type == 'root_block':
+            if block_type == "root_block":
                 return True
             else:
-                LOGGER.critical('Sheet has unterminated block.')
+                LOGGER.critical("Sheet has unterminated block.")
         elif row.type in block_end_map:
             if block_end_map[row.type] == block_type:
                 return True
             else:
-                LOGGER.critical(f'Wrong block terminator "{row.type}" found for block of type {block_type}.')
+                LOGGER.critical(
+                    f'Wrong block terminator "{row.type}" found for block of type {block_type}.'
+                )
         return False
 
     def _parse_insert_as_block_row(self, row):
         if self.content_index_parser is None:
-            LOGGER.critical('insert_as_block only works if FlowParser has a ContentIndexParser')
-        node_group = self.content_index_parser.get_node_group(row.mainarg_flow_name, row.data_sheet, row.data_row_id, row.template_arguments)
+            LOGGER.critical(
+                "insert_as_block only works if FlowParser has a ContentIndexParser"
+            )
+        node_group = self.content_index_parser.get_node_group(
+            row.mainarg_flow_name,
+            row.data_sheet,
+            row.data_row_id,
+            row.template_arguments,
+        )
         for edge in row.edges:
             self._add_row_edge(edge, node_group.entry_node().uuid)
         self.append_node_group(node_group, row.row_id)
@@ -388,56 +431,77 @@ class FlowParser:
             self.row_id_to_nodegroup[row.row_id] = node_group
 
     def _get_row_action(self, row):
-        if row.type == 'send_message':
+        if row.type == "send_message":
             templating = None
             if row.wa_template.name:
-                templating = WhatsAppMessageTemplating(name=row.wa_template.name, template_uuid=row.wa_template.uuid, variables=row.wa_template.variables)
-            send_message_action = SendMessageAction(text=row.mainarg_message_text, templating=templating)
-            for att_type, attachment in zip(["image", "audio", "video"], [row.image, row.audio, row.video]):
+                templating = WhatsAppMessageTemplating(
+                    name=row.wa_template.name,
+                    template_uuid=row.wa_template.uuid,
+                    variables=row.wa_template.variables,
+                )
+            send_message_action = SendMessageAction(
+                text=row.mainarg_message_text, templating=templating
+            )
+            for att_type, attachment in zip(
+                ["image", "audio", "video"], [row.image, row.audio, row.video]
+            ):
                 if attachment:
                     # TODO: Add depending on prefix.
-                    send_message_action.add_attachment(f'{att_type}:{attachment}')
+                    send_message_action.add_attachment(f"{att_type}:{attachment}")
 
             quick_replies = [qr for qr in row.choices if qr]
             if quick_replies:
                 for qr in quick_replies:
                     send_message_action.add_quick_reply(qr)
             return send_message_action
-        elif row.type == 'save_value':
-            set_contact_field_action = SetContactFieldAction(field_name=row.save_name, value=row.mainarg_value)
+        elif row.type == "save_value":
+            set_contact_field_action = SetContactFieldAction(
+                field_name=row.save_name, value=row.mainarg_value
+            )
             return set_contact_field_action
-        elif row.type == 'add_to_group':
+        elif row.type == "add_to_group":
             group = self._get_or_create_group(row.mainarg_groups[0], row.obj_id)
             add_group_action = AddContactGroupAction(groups=[group])
             return add_group_action
-        elif row.type == 'remove_from_group':
+        elif row.type == "remove_from_group":
             group = self._get_or_create_group(row.mainarg_groups[0], row.obj_id)
             remove_group_action = RemoveContactGroupAction(groups=[group])
             return remove_group_action
-        elif row.type == 'save_flow_result':
-            set_run_result_action = SetRunResultAction(row.save_name, row.mainarg_value, category=row.result_category)
+        elif row.type == "save_flow_result":
+            set_run_result_action = SetRunResultAction(
+                row.save_name, row.mainarg_value, category=row.result_category
+            )
             return set_run_result_action
-        elif row.type.startswith('set_contact_'):
-            property = row.type.replace('set_contact_', '')
-            if not property in ['channel', 'language', 'name', 'status', 'timezone']:
-                LOGGER.error(f'Unknown operation set_contact_{property}.')
+        elif row.type.startswith("set_contact_"):
+            property = row.type.replace("set_contact_", "")
+            if not property in ["channel", "language", "name", "status", "timezone"]:
+                LOGGER.error(f"Unknown operation set_contact_{property}.")
             action = SetContactPropertyAction(property, row.mainarg_value)
             return action
-        elif row.type in ['wait_for_response', 'split_by_value', 'split_by_group', 'split_random', 'start_new_flow']:
+        elif row.type in [
+            "wait_for_response",
+            "split_by_value",
+            "split_by_group",
+            "split_random",
+            "start_new_flow",
+        ]:
             return None
         else:
-            LOGGER.error(f'Row type {row.type} not implemented')
+            LOGGER.error(f"Row type {row.type} not implemented")
 
     def _get_or_create_group(self, name, uuid=None):
         # TODO: support lists of groups
         if not uuid:
-        # This shouldn't be necessary, but we keep it until we
-        # have tests checking for group UUIDs.
+            # This shouldn't be necessary, but we keep it until we
+            # have tests checking for group UUIDs.
             uuid = None
         return Group(name=name, uuid=uuid)
 
     def _get_row_node(self, row):
-        if row.type in ['add_to_group', 'remove_from_group', 'split_by_group'] and row.obj_id:
+        if (
+            row.type in ["add_to_group", "remove_from_group", "split_by_group"]
+            and row.obj_id
+        ):
             self.rapidpro_container.record_group_uuid(row.mainarg_groups[0], row.obj_id)
 
         # TODO: Consider whether to put the functionality of getting
@@ -446,34 +510,70 @@ class FlowParser:
         node_uuid = row.node_uuid or None
         if row.ui_position:
             try:
-                ui_pos = [int(coord) for coord in row.ui_position]  # List[str] -> List[int]
+                ui_pos = [
+                    int(coord) for coord in row.ui_position
+                ]  # List[str] -> List[int]
             except ValueError:
-                LOGGER.warn('UI position coordinates have to be integers')
+                LOGGER.warn("UI position coordinates have to be integers")
                 ui_pos = None
             if not ui_pos or len(ui_pos) != 2:
-                LOGGER.warn('A UI position must consist of exactly two coordiates')
+                LOGGER.warn("A UI position must consist of exactly two coordiates")
                 ui_pos = None
         else:
             ui_pos = None
-        if row.type in ['send_message', 'save_value', 'add_to_group', 'remove_from_group', 'save_flow_result']:
+        if row.type in [
+            "send_message",
+            "save_value",
+            "add_to_group",
+            "remove_from_group",
+            "save_flow_result",
+        ]:
             node = BasicNode(uuid=node_uuid, ui_pos=ui_pos)
             node.update_default_exit(None)
             return node
-        elif row.type in ['start_new_flow']:
+        elif row.type in ["start_new_flow"]:
             if row.obj_id:
-                self.rapidpro_container.record_flow_uuid(row.mainarg_flow_name, row.obj_id)
+                self.rapidpro_container.record_flow_uuid(
+                    row.mainarg_flow_name, row.obj_id
+                )
             return EnterFlowNode(row.mainarg_flow_name, uuid=node_uuid, ui_pos=ui_pos)
-        elif row.type in ['wait_for_response']:
+        elif row.type in ["wait_for_response"]:
             if row.no_response:
-                return SwitchRouterNode('@input.text', result_name=row.save_name, wait_timeout=int(row.no_response), uuid=node_uuid, ui_pos=ui_pos)
+                return SwitchRouterNode(
+                    "@input.text",
+                    result_name=row.save_name,
+                    wait_timeout=int(row.no_response),
+                    uuid=node_uuid,
+                    ui_pos=ui_pos,
+                )
             else:
-                return SwitchRouterNode('@input.text', result_name=row.save_name, wait_timeout=0, uuid=node_uuid, ui_pos=ui_pos)
-        elif row.type in ['split_by_value']:
-            return SwitchRouterNode(row.mainarg_expression, result_name=row.save_name, wait_timeout=None, uuid=node_uuid, ui_pos=ui_pos)
-        elif row.type in ['split_by_group']:
-            return SwitchRouterNode('@contact.groups', result_name=row.save_name, wait_timeout=None, uuid=node_uuid, ui_pos=ui_pos)
-        elif row.type in ['split_random']:
-            return RandomRouterNode(result_name=row.save_name, uuid=node_uuid, ui_pos=ui_pos)
+                return SwitchRouterNode(
+                    "@input.text",
+                    result_name=row.save_name,
+                    wait_timeout=0,
+                    uuid=node_uuid,
+                    ui_pos=ui_pos,
+                )
+        elif row.type in ["split_by_value"]:
+            return SwitchRouterNode(
+                row.mainarg_expression,
+                result_name=row.save_name,
+                wait_timeout=None,
+                uuid=node_uuid,
+                ui_pos=ui_pos,
+            )
+        elif row.type in ["split_by_group"]:
+            return SwitchRouterNode(
+                "@contact.groups",
+                result_name=row.save_name,
+                wait_timeout=None,
+                uuid=node_uuid,
+                ui_pos=ui_pos,
+            )
+        elif row.type in ["split_random"]:
+            return RandomRouterNode(
+                result_name=row.save_name, uuid=node_uuid, ui_pos=ui_pos
+            )
         else:
             return BasicNode(uuid=node_uuid, ui_pos=ui_pos)
 
@@ -481,11 +581,13 @@ class FlowParser:
         return row.node_uuid or row.node_name
 
     def _get_node_group_from_edge(self, edge):
-        if edge.from_ == 'start':
+        if edge.from_ == "start":
             return None
         elif edge.from_:
             if edge.from_ not in self.row_id_to_nodegroup:
-                LOGGER.critical(f'Edge from row_id "{edge.from_}" which does not exist.')
+                LOGGER.critical(
+                    f'Edge from row_id "{edge.from_}" which does not exist.'
+                )
             return self.row_id_to_nodegroup[edge.from_]
         else:
             return self.most_recent_node_group()
@@ -496,7 +598,7 @@ class FlowParser:
             #     # Because we have a dummy node group for begin_for/begin_block,
             #     # we actually know this is the first node, and we can issue a warning here:
             #     # 'First node must have edge from "start"'
-            #     return None        
+            #     return None
 
     def _add_row_edge(self, edge, destination_uuid):
         from_node_group = self._get_node_group_from_edge(edge)
@@ -510,7 +612,9 @@ class FlowParser:
         if len(destination_row_ids) == 1:
             destination_row_ids = row.mainarg_destination_row_ids * len(row.edges)
         if not len(row.edges) == len(destination_row_ids):
-            LOGGER.critical('If a go_to has multiple destinations, the number of destinations has to match the number of incoming edges.')
+            LOGGER.critical(
+                "If a go_to has multiple destinations, the number of destinations has to match the number of incoming edges."
+            )
 
         for edge, destination_row_id in zip(row.edges, destination_row_ids):
             destination_node_group = self.row_id_to_nodegroup[destination_row_id]
@@ -522,27 +626,27 @@ class FlowParser:
             source_node_group = self._get_node_group_from_edge(edge)
             if source_node_group is not None:
                 new_node.add_parent_edge(source_node_group, edge.condition)
-        self.append_node_group(new_node, row.row_id if store_row_id else '')
+        self.append_node_group(new_node, row.row_id if store_row_id else "")
 
     def _parse_row(self, row):
         if not row.include_if:
             return
 
-        if row.type in ['hard_exit', 'loose_exit']:
-            destination_uuid = 'HARD_EXIT' if row.type == 'hard_exit' else None
+        if row.type in ["hard_exit", "loose_exit"]:
+            destination_uuid = "HARD_EXIT" if row.type == "hard_exit" else None
             for edge in row.edges:
                 self._add_row_edge(edge, destination_uuid)
             return
 
-        if row.type == 'go_to':
+        if row.type == "go_to":
             self._parse_goto_row(row)
             return
 
-        if row.type == 'no_op':
+        if row.type == "no_op":
             self._parse_noop_row(row)
             return
 
-        if row.type == 'insert_as_block':
+        if row.type == "insert_as_block":
             self._parse_insert_as_block_row(row)
             return
 
@@ -566,12 +670,18 @@ class FlowParser:
                 if predecessor_group.entry_node() == existing_node:
                     existing_node.add_action(row_action)
                     if row.row_id:
-                        self.row_id_to_nodegroup[row.row_id] = self.row_id_to_nodegroup[row.edges[0].from_]
+                        self.row_id_to_nodegroup[row.row_id] = self.row_id_to_nodegroup[
+                            row.edges[0].from_
+                        ]
                     return
                 else:
-                    LOGGER.critical(f'To merge rows using node name "{node_name}" into a single node, edge must come from a rode with node name "{node_name}".')
+                    LOGGER.critical(
+                        f'To merge rows using node name "{node_name}" into a single node, edge must come from a rode with node name "{node_name}".'
+                    )
             else:
-                LOGGER.critical(f'To merge rows using node name "{node_name}" into a single node, there must be exactly one unconditional incoming edge.')
+                LOGGER.critical(
+                    f'To merge rows using node name "{node_name}" into a single node, there must be exactly one unconditional incoming edge.'
+                )
 
         new_node = self._get_row_node(row)
         if row_action:
@@ -585,15 +695,15 @@ class FlowParser:
         self.node_name_to_node_map[self._get_node_name(row)] = new_node
 
     def _compile_flow(self):
-        '''
+        """
         Referenced groups or other flows may have a UUID which is None.
         Add the flow to a RapidProContainer and run update_global_uuids
         to fill in these missing UUIDs in a consistent way.
-        '''
+        """
 
         # Caveat/TODO: Need to ensure starting node comes first.
         flow_container = FlowContainer(flow_name=self.flow_name, uuid=self.flow_uuid)
         if not len(self.node_group_stack) == 1:
-            LOGGER.critical('Unexpected end of flow. Did you forget end_for/end_block?')
+            LOGGER.critical("Unexpected end of flow. Did you forget end_for/end_block?")
         self.current_node_group().add_nodes_to_flow(flow_container)
         return flow_container

--- a/src/rpft/parsers/creation/flowrowmodel.py
+++ b/src/rpft/parsers/creation/flowrowmodel.py
@@ -4,33 +4,35 @@ from pydantic import Field
 
 
 class Condition(ParserModel):
-    value: str = ''  # Technically, this should be a list as a case may have multiple args
-    variable: str = ''
-    type: str = ''
-    name: str = ''
+    value: str = (
+        ""  # Technically, this should be a list as a case may have multiple args
+    )
+    variable: str = ""
+    type: str = ""
+    name: str = ""
     # TODO: We could specify proper default values here, and write custom
     # validators that replace '' with the actual default value.
 
 
 class WhatsAppTemplating(ParserModel):
-    name: str = ''
-    uuid: str = ''
+    name: str = ""
+    uuid: str = ""
     variables: List[str] = []
 
 
 class Edge(ParserModel):
-    from_: str = ''
+    from_: str = ""
     condition: Condition = Condition()
 
     def header_name_to_field_name(header):
         field_map = {
-            "from" : "from_",
+            "from": "from_",
         }
         return field_map.get(header, header)
 
     def field_name_to_header_name(field):
         field_map = {
-            "from_" : "from",
+            "from_": "from",
         }
         return field_map.get(field, field)
 
@@ -39,36 +41,36 @@ class Edge(ParserModel):
 
 
 class FlowRowModel(ParserModel):
-    row_id: str = ''
+    row_id: str = ""
     type: str
     edges: List[Edge]
     # These are the fields that message_text can map to
     loop_variable: List[str] = []
     include_if: bool = True
-    mainarg_message_text: str = ''
-    mainarg_value: str = ''
+    mainarg_message_text: str = ""
+    mainarg_value: str = ""
     mainarg_groups: List[str] = []
-    mainarg_none: str = ''
+    mainarg_none: str = ""
     mainarg_destination_row_ids: List[str] = []
-    mainarg_flow_name: str = ''
-    mainarg_expression: str = ''
-    mainarg_iterlist: list = [] # no specified type of elements
+    mainarg_flow_name: str = ""
+    mainarg_expression: str = ""
+    mainarg_iterlist: list = []  # no specified type of elements
     wa_template: WhatsAppTemplating = WhatsAppTemplating()
-    data_sheet: str = ''
-    data_row_id: str = ''
+    data_sheet: str = ""
+    data_row_id: str = ""
     template_arguments: list = []
     choices: List[str] = []
-    save_name: str = ''
-    result_category: str = ''
-    image: str = ''
-    audio: str = ''
-    video: str = ''
-    obj_name: str = ''  # What is this used for?
-    obj_id: str = ''  # This should be a list
-    node_name: str = ''  # What is this used for?
-    node_uuid: str = ''
-    no_response: str = ''
-    ui_type: str = ''
+    save_name: str = ""
+    result_category: str = ""
+    image: str = ""
+    audio: str = ""
+    video: str = ""
+    obj_name: str = ""  # What is this used for?
+    obj_id: str = ""  # This should be a list
+    node_name: str = ""  # What is this used for?
+    node_uuid: str = ""
+    no_response: str = ""
+    ui_type: str = ""
     ui_position: List[str] = []
 
     # TODO: Extra validation here, e.g. from must not be empty
@@ -80,16 +82,16 @@ class FlowRowModel(ParserModel):
 
     def field_name_to_header_name(field):
         field_map = {
-            "node_uuid" : "_nodeId",
-            "ui_type" : "_ui_type",
-            "ui_position" : "_ui_position",
-            'mainarg_message_text' : 'message_text',
-            'mainarg_value' : 'message_text',
-            'mainarg_groups' : 'message_text',
-            'mainarg_none' : 'message_text',
-            'mainarg_destination_row_ids' : 'message_text',
-            'mainarg_flow_name' : 'message_text',
-            'mainarg_expression' : 'message_text',
+            "node_uuid": "_nodeId",
+            "ui_type": "_ui_type",
+            "ui_position": "_ui_position",
+            "mainarg_message_text": "message_text",
+            "mainarg_value": "message_text",
+            "mainarg_groups": "message_text",
+            "mainarg_none": "message_text",
+            "mainarg_destination_row_ids": "message_text",
+            "mainarg_flow_name": "message_text",
+            "mainarg_expression": "message_text",
             # 'mainarg_iterlist' : 'message_text',  # Not supported for export
         }
         return field_map.get(field, field)
@@ -97,43 +99,43 @@ class FlowRowModel(ParserModel):
     def header_name_to_field_name_with_context(header, row):
         # TODO: This should be defined outside of this function
         basic_header_dict = {
-            "from" : "edges.*.from_",
-            "condition" : "edges.*.condition.value",
-            "condition_value" : "edges.*.condition.value",
-            "condition_var" : "edges.*.condition.variable",
-            "condition_variable" : "edges.*.condition.variable",
-            "condition_type" : "edges.*.condition.type",
-            "condition_name" : "edges.*.condition.name",
-            "_nodeId" : "node_uuid",
-            "_ui_type" : "ui_type",
-            "_ui_position" : "ui_position",
+            "from": "edges.*.from_",
+            "condition": "edges.*.condition.value",
+            "condition_value": "edges.*.condition.value",
+            "condition_var": "edges.*.condition.variable",
+            "condition_variable": "edges.*.condition.variable",
+            "condition_type": "edges.*.condition.type",
+            "condition_name": "edges.*.condition.name",
+            "_nodeId": "node_uuid",
+            "_ui_type": "ui_type",
+            "_ui_position": "ui_position",
         }
         # .update({f"choice_{i}" : f"choices:{i}" for i in range(1,11)})
 
         row_type_to_main_arg = {
-            "send_message" : "mainarg_message_text",
-            "save_value" : "mainarg_value",
-            "add_to_group" : "mainarg_groups",
-            "remove_from_group" : "mainarg_groups",
-            "save_flow_result" : "mainarg_value",
-            "wait_for_response" : "mainarg_none",
-            "set_contact_language" : "mainarg_value",
-            "set_contact_name" : "mainarg_value",
-            "set_contact_status" : "mainarg_value",
-            "set_contact_timezone" : "mainarg_value",
-            "split_random" : "mainarg_none",
-            "go_to" : "mainarg_destination_row_ids",
-            "start_new_flow" : "mainarg_flow_name",
-            "split_by_value" : "mainarg_expression",
-            "split_by_group" : "mainarg_groups",
-            "insert_as_block" : "mainarg_flow_name",
-            "begin_for" : "mainarg_iterlist",
-            "end_for" : "mainarg_none",
-            "begin_block" : "mainarg_none",
-            "end_block" : "mainarg_none",
-            "hard_exit" : "mainarg_none",
-            "loose_exit" : "mainarg_none",
-            "no_op" : "mainarg_none",
+            "send_message": "mainarg_message_text",
+            "save_value": "mainarg_value",
+            "add_to_group": "mainarg_groups",
+            "remove_from_group": "mainarg_groups",
+            "save_flow_result": "mainarg_value",
+            "wait_for_response": "mainarg_none",
+            "set_contact_language": "mainarg_value",
+            "set_contact_name": "mainarg_value",
+            "set_contact_status": "mainarg_value",
+            "set_contact_timezone": "mainarg_value",
+            "split_random": "mainarg_none",
+            "go_to": "mainarg_destination_row_ids",
+            "start_new_flow": "mainarg_flow_name",
+            "split_by_value": "mainarg_expression",
+            "split_by_group": "mainarg_groups",
+            "insert_as_block": "mainarg_flow_name",
+            "begin_for": "mainarg_iterlist",
+            "end_for": "mainarg_none",
+            "begin_block": "mainarg_none",
+            "end_block": "mainarg_none",
+            "hard_exit": "mainarg_none",
+            "loose_exit": "mainarg_none",
+            "no_op": "mainarg_none",
         }
 
         if header in basic_header_dict:
@@ -143,6 +145,6 @@ class FlowRowModel(ParserModel):
         return header
 
     def is_starting_row(self):
-        if len(self.edges) == 1 and self.edges[0].from_ == 'start':
+        if len(self.edges) == 1 and self.edges[0].from_ == "start":
             return True
         return False

--- a/src/rpft/parsers/creation/tagmatcher.py
+++ b/src/rpft/parsers/creation/tagmatcher.py
@@ -1,27 +1,29 @@
 import collections
 
+
 class TagMatcher:
-	def __init__(self, params=[]):		
-		self.tag_patterns = collections.defaultdict(list)
-		if not params:
-			return
-		current_index = None
-		for param in params:
-			try:
-				val = int(param) - 1
-			except ValueError:
-				val = None
-			if val is not None:
-				current_index = val
-			else:
-				if current_index is None:
-					raise ValueError("Tags parameter must start with a number indicating the tag position.")
-				self.tag_patterns[current_index].append(param)
+    def __init__(self, params=[]):
+        self.tag_patterns = collections.defaultdict(list)
+        if not params:
+            return
+        current_index = None
+        for param in params:
+            try:
+                val = int(param) - 1
+            except ValueError:
+                val = None
+            if val is not None:
+                current_index = val
+            else:
+                if current_index is None:
+                    raise ValueError(
+                        "Tags parameter must start with a number indicating the tag position."
+                    )
+                self.tag_patterns[current_index].append(param)
 
-	def matches(self, tags):
-		matches = True
-		for i, tag in enumerate(tags):
-			if tag and i in self.tag_patterns and tag not in self.tag_patterns[i]:
-				matches = False
-		return matches
-
+    def matches(self, tags):
+        matches = True
+        for i, tag in enumerate(tags):
+            if tag and i in self.tag_patterns and tag not in self.tag_patterns[i]:
+                matches = False
+        return matches

--- a/src/rpft/parsers/creation/template_sheet_parser.py
+++ b/src/rpft/parsers/creation/template_sheet_parser.py
@@ -19,7 +19,12 @@ class TemplateSheetParser:
         rapidpro_container = RapidProContainer()
 
         for row in template_rows:
-            parser = FlowParser(rapidpro_container, table=flow_definition_table, flow_name=row.ID, context=dict(row))
+            parser = FlowParser(
+                rapidpro_container,
+                table=flow_definition_table,
+                flow_name=row.ID,
+                context=dict(row),
+            )
             parser.parse()
 
         return rapidpro_container

--- a/src/rpft/parsers/sheets/csv_sheet_reader.py
+++ b/src/rpft/parsers/sheets/csv_sheet_reader.py
@@ -1,12 +1,12 @@
 import tablib
 import os
 
-class CSVSheetReader:
 
+class CSVSheetReader:
     def __init__(self, filename):
         self.path = os.path.dirname(filename)
-        with open(filename, 'r') as table_data:
-            self.main_sheet = tablib.import_set(table_data, format='csv')
+        with open(filename, "r") as table_data:
+            self.main_sheet = tablib.import_set(table_data, format="csv")
 
     def get_main_sheet(self):
         return self.main_sheet
@@ -14,6 +14,6 @@ class CSVSheetReader:
     def get_sheet(self, name):
         # Assume same path as the main sheet, and take sheet names
         # relative to that path.
-        with open(os.path.join(self.path, f'{name}.csv'), 'r') as table_data:
-            table = tablib.import_set(table_data, format='csv')
+        with open(os.path.join(self.path, f"{name}.csv"), "r") as table_data:
+            table = tablib.import_set(table_data, format="csv")
         return table

--- a/src/rpft/parsers/sheets/xlsx_sheet_reader.py
+++ b/src/rpft/parsers/sheets/xlsx_sheet_reader.py
@@ -2,14 +2,13 @@ import tablib
 
 
 class XLSXSheetReader:
-
     def __init__(self, filename):
-        with open(filename, 'rb') as table_data:
-            data = tablib.Databook().load(table_data.read(), 'xlsx')
+        with open(filename, "rb") as table_data:
+            data = tablib.Databook().load(table_data.read(), "xlsx")
         self.main_sheet = None
         self.sheets = {}
         for sheet in data.sheets():
-            if sheet.title == 'content_index':
+            if sheet.title == "content_index":
                 self.main_sheet = self._sanitize(sheet)
             else:
                 self.sheets[sheet.title] = self._sanitize(sheet)
@@ -20,7 +19,7 @@ class XLSXSheetReader:
         data = tablib.Dataset()
         data.headers = sheet.headers
         for row in sheet:
-            new_row = tuple(str(e) if e is not None else '' for e in row)
+            new_row = tuple(str(e) if e is not None else "" for e in row)
             data.append(new_row)
         return data
 

--- a/src/rpft/rapidpro/models/campaigns.py
+++ b/src/rpft/rapidpro/models/campaigns.py
@@ -5,30 +5,48 @@ from rpft.rapidpro.models.common import Group, FlowReference, ContactFieldRefere
 
 
 class CampaignEvent:
-    def __init__(self, 
-            offset, unit, event_type, delivery_hour, start_mode, uuid=None,
-            relative_to=None, relative_to_key=None, relative_to_label=None, 
-            message=None, flow=None, flow_name=None, flow_uuid=None,
-            base_language=None):
+    def __init__(
+        self,
+        offset,
+        unit,
+        event_type,
+        delivery_hour,
+        start_mode,
+        uuid=None,
+        relative_to=None,
+        relative_to_key=None,
+        relative_to_label=None,
+        message=None,
+        flow=None,
+        flow_name=None,
+        flow_uuid=None,
+        base_language=None,
+    ):
         self.uuid = uuid if uuid else generate_new_uuid()
         self.offset = offset
         self.unit = unit
         self.event_type = event_type
         self.delivery_hour = delivery_hour
         self.message = message  # This is a dict whose keys are language IDs and values are message text
-        self.relative_to = relative_to or ContactFieldReference(relative_to_label, relative_to_key)
+        self.relative_to = relative_to or ContactFieldReference(
+            relative_to_label, relative_to_key
+        )
         self.start_mode = start_mode
         self.flow = flow or FlowReference(flow_name, flow_uuid)
         self.base_language = base_language
-        if event_type == 'M' and (message is None or base_language is None):
-            raise ValueError("CampaignEvent must have a message and base_language if the event_type is M")
-        if event_type == 'F' and self.flow is None:
+        if event_type == "M" and (message is None or base_language is None):
+            raise ValueError(
+                "CampaignEvent must have a message and base_language if the event_type is M"
+            )
+        if event_type == "F" and self.flow is None:
             raise ValueError("CampaignEvent must have a flow if the event_type is F")
 
     def from_dict(data):
         data_copy = copy.deepcopy(data)
         # What is called 'label' here is normally it's called 'name' for contact fields.
-        data_copy["relative_to"] = ContactFieldReference(data_copy["relative_to"]["label"], data_copy["relative_to"]["key"])
+        data_copy["relative_to"] = ContactFieldReference(
+            data_copy["relative_to"]["label"], data_copy["relative_to"]["key"]
+        )
         if "flow" in data_copy:
             data_copy["flow"] = FlowReference(**data_copy["flow"])
         return CampaignEvent(**data_copy)
@@ -43,24 +61,26 @@ class CampaignEvent:
 
     def render(self):
         render_dict = {
-            "uuid" : self.uuid,
-            "offset" : self.offset,
-            "unit" : self.unit,
-            "event_type" : self.event_type,
-            "delivery_hour" : self.delivery_hour,
-            "message" : self.message,
-            "relative_to" : self.relative_to.render_with_label(),
-            "start_mode" : self.start_mode,
+            "uuid": self.uuid,
+            "offset": self.offset,
+            "unit": self.unit,
+            "event_type": self.event_type,
+            "delivery_hour": self.delivery_hour,
+            "message": self.message,
+            "relative_to": self.relative_to.render_with_label(),
+            "start_mode": self.start_mode,
         }
-        if self.event_type == 'F' and self.flow:
+        if self.event_type == "F" and self.flow:
             render_dict.update({"flow": self.flow.render()})
-        if self.event_type == 'M' and self.base_language:
+        if self.event_type == "M" and self.base_language:
             render_dict.update({"base_language": self.base_language})
         return render_dict
 
 
 class Campaign:
-    def __init__(self, name, group=None, group_name=None, group_uuid=None, events=None, uuid=None):
+    def __init__(
+        self, name, group=None, group_name=None, group_uuid=None, events=None, uuid=None
+    ):
         self.name = name
         self.group = group or Group(group_name, group_uuid)
         self.uuid = uuid if uuid else generate_new_uuid()
@@ -74,10 +94,10 @@ class Campaign:
         assert "name" in data
         assert "events" in data
         return Campaign(
-                uuid=data.get("uuid"),
-                name=data["name"],
-                group=Group.from_dict(data["group"]),
-                events=[CampaignEvent.from_dict(event) for event in data["events"]],
+            uuid=data.get("uuid"),
+            name=data["name"],
+            group=Group.from_dict(data["group"]),
+            events=[CampaignEvent.from_dict(event) for event in data["events"]],
         )
 
     def record_global_uuids(self, uuid_dict):
@@ -92,8 +112,8 @@ class Campaign:
 
     def render(self):
         return {
-            'group': self.group.render(),
-            'name': self.name,
-            'uuid': self.uuid,
-            'events': [event.render() for event in self.events]
+            "group": self.group.render(),
+            "name": self.name,
+            "uuid": self.uuid,
+            "events": [event.render() for event in self.events],
         }

--- a/src/rpft/rapidpro/models/common.py
+++ b/src/rpft/rapidpro/models/common.py
@@ -18,17 +18,17 @@ class Exit:
         # By default, when attaching nodes to the end of a block, all
         # unconnected exits from the block are connected, however,
         # hard exits are omitted and exit the flow.
-        if self.destination_uuid == 'HARD_EXIT':
+        if self.destination_uuid == "HARD_EXIT":
             return True
         return False
 
     def render(self):
         destination_uuid = self.destination_uuid
-        if self.destination_uuid == 'HARD_EXIT':
+        if self.destination_uuid == "HARD_EXIT":
             destination_uuid = None
         return {
-            'destination_uuid': destination_uuid,
-            'uuid': self.uuid,
+            "destination_uuid": destination_uuid,
+            "uuid": self.uuid,
         }
 
 
@@ -47,18 +47,19 @@ class FlowReference:
         self.uuid = uuid_dict.get_flow_uuid(self.name)
 
     def render(self):
-        return {
-            'name': self.name,
-            'uuid': self.uuid
-        }
+        return {"name": self.name, "uuid": self.uuid}
 
 
 def generate_field_key(field_name):
-    field_key = field_name.strip().lower().replace(' ', '_')
+    field_key = field_name.strip().lower().replace(" ", "_")
     if not len(field_key) <= 36:
-        raise RapidProActionError('Contact field keys should be no longer than 36 characters.')
-    if not re.search('[A-Za-z]', field_key):
-        raise RapidProActionError('Contact field keys should contain at least one letter.')
+        raise RapidProActionError(
+            "Contact field keys should be no longer than 36 characters."
+        )
+    if not re.search("[A-Za-z]", field_key):
+        raise RapidProActionError(
+            "Contact field keys should contain at least one letter."
+        )
     return field_key
 
 
@@ -72,19 +73,13 @@ class ContactFieldReference:
         self.type = type
 
     def render(self):
-        render_dict = {
-            'name': self.name,
-            'key': self.key
-        }
+        render_dict = {"name": self.name, "key": self.key}
         if self.type:
             render_dict["type"] = type
         return render_dict
 
     def render_with_label(self):
-        return {
-            'label': self.name,
-            'key': self.key
-        }
+        return {"label": self.name, "key": self.key}
 
 
 class Group:
@@ -103,10 +98,7 @@ class Group:
         self.uuid = uuid_dict.get_group_uuid(self.name)
 
     def render(self):
-        render_dict = {
-            'name': self.name,
-            'uuid': self.uuid
-        }
+        render_dict = {"name": self.name, "uuid": self.uuid}
         if self.query:
             render_dict["query"] = query
         return render_dict

--- a/src/rpft/rapidpro/models/exceptions.py
+++ b/src/rpft/rapidpro/models/exceptions.py
@@ -1,4 +1,3 @@
-
 class RapidProActionError(Exception):
     "Raise if some parameter of a RapidProAction is invalid."
     pass

--- a/src/rpft/rapidpro/models/routers.py
+++ b/src/rpft/rapidpro/models/routers.py
@@ -23,12 +23,15 @@ class BaseRouter:
             raise ValueError("Router data has invalid router type.")
 
     def _get_result_name_and_categories_from_data(data, exits):
-        categories = [RouterCategory.from_dict(category_data, exits) for category_data in data["categories"]]
+        categories = [
+            RouterCategory.from_dict(category_data, exits)
+            for category_data in data["categories"]
+        ]
         result_name = None
         if "result_name" in data:
             result_name = data["result_name"]
         return result_name, categories
-        
+
     def set_result_name(self, result_name):
         # TODO: Check that this works
         self.result_name = result_name
@@ -74,18 +77,27 @@ class BaseRouter:
     def get_exit_edge_pairs(self, row_id):
         raise NotImplementedError
 
-class SwitchRouter(BaseRouter):
 
-    def __init__(self, operand, result_name=None, wait_timeout=None, cases=None, categories=None, default_category=None, no_response_category=None):
-        '''
+class SwitchRouter(BaseRouter):
+    def __init__(
+        self,
+        operand,
+        result_name=None,
+        wait_timeout=None,
+        cases=None,
+        categories=None,
+        default_category=None,
+        no_response_category=None,
+    ):
+        """
         wait_timeout:
             None: There is no waiting for a user's message in this router
             0: Waiting for user's message, without a timeout
             >0: Waiting for user's message, with a timeout (in which case no_response_category is taken)
-        '''
+        """
 
         super().__init__(result_name)
-        self.type = 'switch'
+        self.type = "switch"
         self.operand = operand
         self.cases = cases or []
         self.wait_timeout = wait_timeout
@@ -99,7 +111,7 @@ class SwitchRouter(BaseRouter):
         else:
             self.categories = []
             # Add an implicit default category
-            category = RouterCategory('Other', None)
+            category = RouterCategory("Other", None)
             self.default_category = category
 
         self.has_explicit_no_response_category = False
@@ -109,17 +121,25 @@ class SwitchRouter(BaseRouter):
                 # Indicates that a No Response category has been added by the user
                 self.has_explicit_no_response_category = True
             else:
-                category = RouterCategory('No Response', None)
+                category = RouterCategory("No Response", None)
                 self.no_response_category = category
         else:
             self.no_response_category = None
             if no_response_category:
-                logger.warning(f'Router has No Response category but no wait timeout. Ignoring No Response category.')
+                logger.warning(
+                    f"Router has No Response category but no wait timeout. Ignoring No Response category."
+                )
 
     def from_dict(data, exits):
-        result_name, categories = BaseRouter._get_result_name_and_categories_from_data(data, exits)
+        result_name, categories = BaseRouter._get_result_name_and_categories_from_data(
+            data, exits
+        )
         cases = [RouterCase.from_dict(case_data) for case_data in data["cases"]]
-        default_categories = [category for category in categories if category.uuid == data["default_category_uuid"]]
+        default_categories = [
+            category
+            for category in categories
+            if category.uuid == data["default_category_uuid"]
+        ]
         if not default_categories:
             raise ValueError("Default category uuid does not match any category.")
         no_response_category = None
@@ -130,17 +150,35 @@ class SwitchRouter(BaseRouter):
             if "timeout" in data["wait"]:
                 no_response_category_id = data["wait"]["timeout"]["category_uuid"]
                 wait_timeout = int(data["wait"]["timeout"]["seconds"])
-                no_response_categories = [category for category in categories if category.uuid == no_response_category_id]
+                no_response_categories = [
+                    category
+                    for category in categories
+                    if category.uuid == no_response_category_id
+                ]
                 if not no_response_categories:
-                    raise ValueError("No Response category uuid does not match any category.")
+                    raise ValueError(
+                        "No Response category uuid does not match any category."
+                    )
                 no_response_category = no_response_categories[0]
-        other_categories = [category for category in categories if category.uuid not in [data["default_category_uuid"], no_response_category_id]]
-        return SwitchRouter(data["operand"], result_name, wait_timeout, cases, other_categories, default_categories[0], no_response_category)
+        other_categories = [
+            category
+            for category in categories
+            if category.uuid
+            not in [data["default_category_uuid"], no_response_category_id]
+        ]
+        return SwitchRouter(
+            data["operand"],
+            result_name,
+            wait_timeout,
+            cases,
+            other_categories,
+            default_categories[0],
+            no_response_category,
+        )
 
     def _get_case_or_none(self, comparison_type, arguments):
         for case in self.cases:
-            if case.type == comparison_type \
-                    and case.arguments == arguments:
+            if case.type == comparison_type and case.arguments == arguments:
                 return case
 
     def _add_case(self, comparison_type, arguments, category_uuid):
@@ -154,13 +192,20 @@ class SwitchRouter(BaseRouter):
     def generate_category_name(self, comparison_arguments):
         # Auto-generate a category name that is guaranteed to be unique
         # TODO: Write tests for this
-        category_name = '_'.join([str(a).title() for a in comparison_arguments])
+        category_name = "_".join([str(a).title() for a in comparison_arguments])
         while self._get_category_or_none(category_name):
             category_name += "_alt"
         return category_name
 
-    def add_choice(self, comparison_variable, comparison_type, comparison_arguments, category_name,
-                   destination_uuid, is_default=False):
+    def add_choice(
+        self,
+        comparison_variable,
+        comparison_type,
+        comparison_arguments,
+        category_name,
+        destination_uuid,
+        is_default=False,
+    ):
         self.set_operand(comparison_variable)
         case = self._get_case_or_none(comparison_type, comparison_arguments)
         if case:
@@ -182,7 +227,7 @@ class SwitchRouter(BaseRouter):
 
     def update_default_category(self, destination_uuid, category_name=None):
         if self.has_explicit_default_category:
-            logger.warning(f'Overwriting default category for Router')
+            logger.warning(f"Overwriting default category for Router")
         self.default_category.update_destination_uuid(destination_uuid)
         if category_name:
             self.default_category.update_name(category_name)
@@ -191,9 +236,11 @@ class SwitchRouter(BaseRouter):
 
     def update_no_response_category(self, destination_uuid, category_name=None):
         if not self.wait_timeout:
-            logger.warning(f'Updating No Response category, but router has no wait timeout.')
+            logger.warning(
+                f"Updating No Response category, but router has no wait timeout."
+            )
         if self.has_explicit_no_response_category:
-            logger.warning(f'Overwriting No Response category for Router')
+            logger.warning(f"Overwriting No Response category for Router")
         self.no_response_category.update_destination_uuid(destination_uuid)
         if category_name:
             self.no_response_category.update_name(category_name)
@@ -208,7 +255,9 @@ class SwitchRouter(BaseRouter):
 
     def get_categories(self):
         if self.no_response_category:
-            return self.categories + [self.default_category] + [self.no_response_category]
+            return (
+                self.categories + [self.default_category] + [self.no_response_category]
+            )
         else:
             return self.categories + [self.default_category]
 
@@ -216,18 +265,18 @@ class SwitchRouter(BaseRouter):
         if not operand:
             return
         if self.operand and operand and self.operand != operand:
-            logger.warning(f'Overwriting operand from {self.operand} -> {operand}')
+            logger.warning(f"Overwriting operand from {self.operand} -> {operand}")
 
         self.operand = operand
 
     def record_global_uuids(self, uuid_dict):
         for case in self.cases:
-            if case.type == 'has_group':
+            if case.type == "has_group":
                 uuid_dict.record_group_uuid(case.arguments[1], case.arguments[0])
 
     def assign_global_uuids(self, uuid_dict):
         for case in self.cases:
-            if case.type == 'has_group':
+            if case.type == "has_group":
                 case.arguments[0] = uuid_dict.get_group_uuid(case.arguments[1])
 
     def validate(self):
@@ -245,28 +294,30 @@ class SwitchRouter(BaseRouter):
             "operand": self.operand,
             "cases": [case.render() for case in self.cases],
             "categories": [category.render() for category in self.get_categories()],
-            "default_category_uuid": self.default_category.uuid
+            "default_category_uuid": self.default_category.uuid,
         }
         if self.has_positive_wait():
-            render_dict.update({
-                "wait": {
-                    "type": "msg",
-                    "timeout" : {
-                        "seconds" : self.wait_timeout,
-                        "category_uuid" : self.no_response_category.uuid
+            render_dict.update(
+                {
+                    "wait": {
+                        "type": "msg",
+                        "timeout": {
+                            "seconds": self.wait_timeout,
+                            "category_uuid": self.no_response_category.uuid,
+                        },
                     }
                 }
-            })
+            )
         elif self.has_wait():
-            render_dict.update({
-                "wait": {
-                    "type": "msg",
+            render_dict.update(
+                {
+                    "wait": {
+                        "type": "msg",
+                    }
                 }
-            })
+            )
         if self.result_name is not None:
-            render_dict.update({
-                "result_name": self.result_name
-            })
+            render_dict.update({"result_name": self.result_name})
         return render_dict
 
     def get_exit_edge_pairs(self, row_id):
@@ -278,11 +329,16 @@ class SwitchRouter(BaseRouter):
                 if case.category_uuid == category.uuid:
                     covered_category_uuids.add(category.uuid)
                     arg_idx = 1 if self.operand == "@contact.groups" else 0
-                    if self.operand in ['@contact.groups', '@child.run.status']:
+                    if self.operand in ["@contact.groups", "@child.run.status"]:
                         # For groups and expired/complete, var/type/name are implicit
                         condition = Condition(value=case.arguments[arg_idx])
                     else:
-                        condition = Condition(value=case.arguments[arg_idx], variable=self.operand, type=case.type, name=category.name)
+                        condition = Condition(
+                            value=case.arguments[arg_idx],
+                            variable=self.operand,
+                            type=case.type,
+                            name=category.name,
+                        )
                     pairs.append(
                         (category.exit, Edge(from_=row_id, condition=condition))
                     )
@@ -290,24 +346,33 @@ class SwitchRouter(BaseRouter):
         if self.default_category.uuid not in covered_category_uuids:
             # Sometimes, the default category is already covered by a specific case.
             # In that case, its edge has already been covered.
-            pairs.append((self.default_category.exit, Edge(from_=row_id)))  # By convention, the condition is blank rather than 'Other'
+            pairs.append(
+                (self.default_category.exit, Edge(from_=row_id))
+            )  # By convention, the condition is blank rather than 'Other'
         if self.no_response_category:
-            pairs.append((self.no_response_category.exit, Edge(from_=row_id, condition=Condition(value=category.name))))
+            pairs.append(
+                (
+                    self.no_response_category.exit,
+                    Edge(from_=row_id, condition=Condition(value=category.name)),
+                )
+            )
         return pairs
 
 
 class RandomRouter(BaseRouter):
     def __init__(self, result_name=None, categories=None):
         super().__init__(result_name, categories)
-        self.type = 'random'
+        self.type = "random"
 
     def from_dict(data, exits):
-        result_name, categories = BaseRouter._get_result_name_and_categories_from_data(data, exits)
+        result_name, categories = BaseRouter._get_result_name_and_categories_from_data(
+            data, exits
+        )
         return RandomRouter(result_name, categories)
 
     def add_choice(self, category_name=None, destination_uuid=None):
         if not category_name:
-            category = f'Bucket {len(self.categories) + 2}'
+            category = f"Bucket {len(self.categories) + 2}"
         self.get_or_create_category(category_name, destination_uuid)
 
     def get_categories(self):
@@ -320,25 +385,28 @@ class RandomRouter(BaseRouter):
     def render(self):
         render_dict = {
             "type": self.type,
-            "categories": [category.render() for category in self.categories]
+            "categories": [category.render() for category in self.categories],
         }
         if self.result_name:
-            render_dict.update({
-                "result_name": self.result_name
-            })
+            render_dict.update({"result_name": self.result_name})
         return render_dict
 
     def get_exit_edge_pairs(self, row_id):
         pairs = []
         for category in self.categories:
             pairs.append(
-                (category.exit, Edge(from_=row_id, condition=Condition(value=category.name)))
+                (
+                    category.exit,
+                    Edge(from_=row_id, condition=Condition(value=category.name)),
+                )
             )
         return pairs
 
 
 class RouterCategory:
-    def __init__(self, name, destination_uuid=None, uuid=None, exit_uuid=None, exit=None):
+    def __init__(
+        self, name, destination_uuid=None, uuid=None, exit_uuid=None, exit=None
+    ):
         """
         :param name: Name of the category
         :param destination_uuid: The UUID of the node that this category should point to
@@ -350,7 +418,9 @@ class RouterCategory:
         if exit:
             self.exit = exit
         else:
-            self.exit = Exit(uuid=exit_uuid or generate_new_uuid(), destination_uuid=destination_uuid)
+            self.exit = Exit(
+                uuid=exit_uuid or generate_new_uuid(), destination_uuid=destination_uuid
+            )
 
     def from_dict(data, exits):
         """
@@ -360,7 +430,9 @@ class RouterCategory:
         matching_exits = [exit for exit in exits if exit.uuid == data["exit_uuid"]]
         if not matching_exits:
             raise ValueError("RouterCategory with no matching exit.")
-        return RouterCategory(name=data["name"], uuid=data["uuid"], exit=matching_exits[0])
+        return RouterCategory(
+            name=data["name"], uuid=data["uuid"], exit=matching_exits[0]
+        )
 
     def get_exit(self):
         return self.exit
@@ -369,58 +441,58 @@ class RouterCategory:
         self.exit.destination_uuid = uuid
 
     def update_name(self, name):
-        self.name = name 
+        self.name = name
 
     def render(self):
         return {
-            'uuid': self.uuid,
-            'name': self.name,
-            'exit_uuid': self.exit.uuid,
+            "uuid": self.uuid,
+            "name": self.name,
+            "exit_uuid": self.exit.uuid,
         }
 
 
 class RouterCase:
     NO_ARGS_TESTS = {
-        "has_date", 
-        "has_email", 
-        "has_error", 
-        "has_number", 
-        "has_state", 
-        "has_text", 
-        "has_time", 
+        "has_date",
+        "has_email",
+        "has_error",
+        "has_number",
+        "has_state",
+        "has_text",
+        "has_time",
     }
 
     TEST_VALIDATIONS = {
-        "all_words" : lambda x: len(x) == 1,
-        "has_any_word" : lambda x: len(x) == 1,
-        "has_beginning" : lambda x: len(x) == 1,
-        "has_category" : lambda x: len(x) >= 1,
-        "has_date" : lambda x: len(x) == 0,
-        "has_date_eq" : lambda x: len(x) == 1,
-        "has_date_gt" : lambda x: len(x) == 1,
-        "has_date_lt" : lambda x: len(x) == 1,
-        "has_district" : lambda x: len(x) == 1,
-        "has_email" : lambda x: len(x) == 0,
-        "has_error" : lambda x: len(x) == 0,
-        "has_group" : lambda x: len(x) in {1, 2},  # uuid obligatory, name optional?
-        "has_intent" : lambda x: len(x) == 2,
-        "has_number" : lambda x: len(x) == 0,
-        "has_number_between" : lambda x: len(x) == 2,
-        "has_number_eq" : lambda x: len(x) == 1,
-        "has_number_gt" : lambda x: len(x) == 1,
-        "has_number_gte" : lambda x: len(x) == 1,
-        "has_number_lt" : lambda x: len(x) == 1,
-        "has_number_lte" : lambda x: len(x) == 1,
-        "has_only_phrase" : lambda x: len(x) == 1,
-        "has_only_text" : lambda x: len(x) == 1,
-        "has_pattern" : lambda x: len(x) == 1,
-        "has_phone" : lambda x: len(x) in {0, 1},
-        "has_phrase" : lambda x: len(x) == 1,
-        "has_state" : lambda x: len(x) == 0,
-        "has_text" : lambda x: len(x) == 0,
-        "has_time" : lambda x: len(x) == 0,
-        "has_top_intent" : lambda x: len(x) == 2,
-        "has_ward" : lambda x: len(x) == 2,
+        "all_words": lambda x: len(x) == 1,
+        "has_any_word": lambda x: len(x) == 1,
+        "has_beginning": lambda x: len(x) == 1,
+        "has_category": lambda x: len(x) >= 1,
+        "has_date": lambda x: len(x) == 0,
+        "has_date_eq": lambda x: len(x) == 1,
+        "has_date_gt": lambda x: len(x) == 1,
+        "has_date_lt": lambda x: len(x) == 1,
+        "has_district": lambda x: len(x) == 1,
+        "has_email": lambda x: len(x) == 0,
+        "has_error": lambda x: len(x) == 0,
+        "has_group": lambda x: len(x) in {1, 2},  # uuid obligatory, name optional?
+        "has_intent": lambda x: len(x) == 2,
+        "has_number": lambda x: len(x) == 0,
+        "has_number_between": lambda x: len(x) == 2,
+        "has_number_eq": lambda x: len(x) == 1,
+        "has_number_gt": lambda x: len(x) == 1,
+        "has_number_gte": lambda x: len(x) == 1,
+        "has_number_lt": lambda x: len(x) == 1,
+        "has_number_lte": lambda x: len(x) == 1,
+        "has_only_phrase": lambda x: len(x) == 1,
+        "has_only_text": lambda x: len(x) == 1,
+        "has_pattern": lambda x: len(x) == 1,
+        "has_phone": lambda x: len(x) in {0, 1},
+        "has_phrase": lambda x: len(x) == 1,
+        "has_state": lambda x: len(x) == 0,
+        "has_text": lambda x: len(x) == 0,
+        "has_time": lambda x: len(x) == 0,
+        "has_top_intent": lambda x: len(x) == 2,
+        "has_ward": lambda x: len(x) == 2,
     }
 
     def __init__(self, comparison_type, arguments, category_uuid, uuid=None):
@@ -434,19 +506,23 @@ class RouterCase:
         self.validate()
 
     def from_dict(data):
-        return RouterCase(data["type"], data["arguments"], data["category_uuid"], data["uuid"])
+        return RouterCase(
+            data["type"], data["arguments"], data["category_uuid"], data["uuid"]
+        )
 
     def validate(self):
         if not self.type in RouterCase.TEST_VALIDATIONS:
             raise ValueError(f'Invalid router test type: "{self.type}"')
         if not RouterCase.TEST_VALIDATIONS[self.type](self.arguments):
-            print(f'Warning: Invalid number of arguments {len(self.arguments)} for router test type "{self.type}"')
+            print(
+                f'Warning: Invalid number of arguments {len(self.arguments)} for router test type "{self.type}"'
+            )
 
     def render(self):
         self.validate()
         return {
-            'uuid': self.uuid,
-            'type': self.type,
-            'category_uuid': self.category_uuid,
-            'arguments': self.arguments,
+            "uuid": self.uuid,
+            "type": self.type,
+            "category_uuid": self.category_uuid,
+            "arguments": self.arguments,
         }

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
 from pathlib import Path
 
 
-TESTS_ROOT=Path(__file__).parent
+TESTS_ROOT = Path(__file__).parent

--- a/tests/datarowmodels/evalmodels.py
+++ b/tests/datarowmodels/evalmodels.py
@@ -1,7 +1,9 @@
 from rpft.parsers.creation.datarowmodel import DataRowModel
 
+
 class EvalMetadataModel(DataRowModel):
-	include_if: str = ''
+    include_if: str = ""
+
 
 class EvalContentModel(DataRowModel):
-	text: str = ''
+    text: str = ""

--- a/tests/datarowmodels/listmodel.py
+++ b/tests/datarowmodels/listmodel.py
@@ -1,14 +1,16 @@
 from rpft.parsers.creation.datarowmodel import DataRowModel
 from typing import List
 
+
 class ListRowModel(DataRowModel):
-	# Because this defines the content of a datasheet,
-	# it inherits DataRowModel, which gives it the ID column.
-	messages: List[str]
+    # Because this defines the content of a datasheet,
+    # it inherits DataRowModel, which gives it the ID column.
+    messages: List[str]
+
 
 class LookupRowModel(DataRowModel):
-	# Because this defines the content of a datasheet,
-	# it inherits DataRowModel, which gives it the ID column.
-	happy: str
-	sad: str
-	neutral: str
+    # Because this defines the content of a datasheet,
+    # it inherits DataRowModel, which gives it the ID column.
+    happy: str
+    sad: str
+    neutral: str

--- a/tests/datarowmodels/nestedmodel.py
+++ b/tests/datarowmodels/nestedmodel.py
@@ -1,14 +1,16 @@
 from rpft.parsers.creation.datarowmodel import DataRowModel
 from rpft.parsers.common.rowparser import ParserModel
 
+
 class CustomModel(ParserModel):
-	# Because this does not directly define the content of a datasheet,
-	# in inherits from ParserModel and not DataRowModel.
-	happy: str = ''
-	sad: str = ''
+    # Because this does not directly define the content of a datasheet,
+    # in inherits from ParserModel and not DataRowModel.
+    happy: str = ""
+    sad: str = ""
+
 
 class NestedRowModel(DataRowModel):
-	# Because this defines the content of a datasheet,
-	# it inherits DataRowModel, which gives it the ID column.
-	value1: str = ''
-	custom_field: CustomModel = CustomModel()  # Default value is an empty custom model
+    # Because this defines the content of a datasheet,
+    # it inherits DataRowModel, which gives it the ID column.
+    value1: str = ""
+    custom_field: CustomModel = CustomModel()  # Default value is an empty custom model

--- a/tests/datarowmodels/simplemodel.py
+++ b/tests/datarowmodels/simplemodel.py
@@ -1,5 +1,6 @@
 from rpft.parsers.creation.datarowmodel import DataRowModel
 
+
 class SimpleRowModel(DataRowModel):
-	value1: str = ''
-	value2: str = ''
+    value1: str = ""
+    value2: str = ""

--- a/tests/input/example1/nestedmodel.py
+++ b/tests/input/example1/nestedmodel.py
@@ -3,13 +3,14 @@ from rpft.parsers.common.rowparser import ParserModel
 
 
 class CustomModel(ParserModel):
-	# Because this does not directly define the content of a datasheet,
-	# in inherits from ParserModel and not DataRowModel.
-	happy: str = ''
-	sad: str = ''
+    # Because this does not directly define the content of a datasheet,
+    # in inherits from ParserModel and not DataRowModel.
+    happy: str = ""
+    sad: str = ""
+
 
 class NestedRowModel(DataRowModel):
-	# Because this defines the content of a datasheet,
-	# it inherits DataRowModel, which gives it the ID column.
-	value1: str = ''
-	custom_field: CustomModel = CustomModel()  # Default value is an empty custom model
+    # Because this defines the content of a datasheet,
+    # it inherits DataRowModel, which gives it the ID column.
+    value1: str = ""
+    custom_field: CustomModel = CustomModel()  # Default value is an empty custom model

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -5,7 +5,6 @@ from rpft.parsers.common.sheetparser import SheetParser
 
 
 class MockCellParser:
-
     def parse(self, value, context={}):
         return value
 
@@ -27,14 +26,13 @@ class MockRowParser:
 
 
 class MockSheetParser(SheetParser):
-
     def __init__(self, row_parser, rows, context={}):
-        '''
+        """
         Args:
             row_parser: parser to convert flat dicts to RowModel instances.
             rows: List of instances of the RowModel
             context: context used for template parsing
-        '''
+        """
 
         self.row_parser = row_parser
         self.bookmarks = {}
@@ -51,12 +49,11 @@ class MockSheetParser(SheetParser):
 
 
 class MockSheetReader:
-
     def __init__(self, main_sheet_data, sheet_data_dict):
-        self.main_sheet = tablib.import_set(main_sheet_data, format='csv')
+        self.main_sheet = tablib.import_set(main_sheet_data, format="csv")
         self.sheet_dict = {}
         for name, content in sheet_data_dict.items():
-            self.sheet_dict[name] = tablib.import_set(content, format='csv')
+            self.sheet_dict[name] = tablib.import_set(content, format="csv")
 
     def get_main_sheet(self):
         return self.main_sheet

--- a/tests/models.py
+++ b/tests/models.py
@@ -3,10 +3,10 @@ from rpft.parsers.common.rowparser import ParserModel
 
 
 class Condition(ParserModel):
-    value: str = ''
-    var: str = ''
-    type: str = ''
-    name: str = ''
+    value: str = ""
+    var: str = ""
+    type: str = ""
+    name: str = ""
     # TODO: We could specify proper default values here, and write custom
     # validators that replace '' with the actual default value.
 
@@ -17,4 +17,3 @@ class FromWrong(ParserModel):
     # It's still useful for the testcases we have though.
     row_id: str
     conditions: List[Condition]
-

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -8,9 +8,8 @@ class TestActions(unittest.TestCase):
         pass
 
     def test_enter_flow_node(self):
-        enter_flow_node = EnterFlowAction(flow_name='test_flow', flow_uuid='fake-uuid')
+        enter_flow_node = EnterFlowAction(flow_name="test_flow", flow_uuid="fake-uuid")
         render_output = enter_flow_node.render()
-        self.assertEqual(render_output['type'], 'enter_flow')
-        self.assertEqual(render_output['flow']['name'], 'test_flow')
-        self.assertEqual(render_output['flow']['uuid'], 'fake-uuid')
-
+        self.assertEqual(render_output["type"], "enter_flow")
+        self.assertEqual(render_output["flow"]["name"], "test_flow")
+        self.assertEqual(render_output["flow"]["uuid"], "fake-uuid")

--- a/tests/test_cellparser.py
+++ b/tests/test_cellparser.py
@@ -8,18 +8,18 @@ from rpft.parsers.common.rowparser import ParserModel
 class InnerModel(ParserModel):
     str_field: str
 
+
 class OuterModel(ParserModel):
     inner: InnerModel
     strings: List[str]
 
 
 class TestStringSplitter(unittest.TestCase):
-
     def setUp(self):
         self.parser = CellParser()
 
     def compare_split_by_separator(self, string, exp):
-        out = self.parser.split_by_separator(string, '|')
+        out = self.parser.split_by_separator(string, "|")
         self.assertEqual(out, exp)
 
     def compare_cleanse(self, string, exp):
@@ -31,111 +31,119 @@ class TestStringSplitter(unittest.TestCase):
         self.assertEqual(out, exp)
 
     def test_split_by_separator(self):
-        self.compare_split_by_separator('a', 'a')
-        self.compare_split_by_separator('a|b', ['a', 'b'])
-        self.compare_split_by_separator('a|b|', ['a', 'b'])
-        self.compare_split_by_separator('a|', ['a'])
-        self.compare_split_by_separator('a\\|', 'a\\|')
+        self.compare_split_by_separator("a", "a")
+        self.compare_split_by_separator("a|b", ["a", "b"])
+        self.compare_split_by_separator("a|b|", ["a", "b"])
+        self.compare_split_by_separator("a|", ["a"])
+        self.compare_split_by_separator("a\\|", "a\\|")
 
     def test_cleanse(self):
-        self.compare_cleanse('a', 'a')
-        self.compare_cleanse('a\\|', 'a|')
-        self.compare_cleanse('a\\;', 'a;')
-        self.compare_cleanse('a\\\\', 'a\\')
-        self.compare_cleanse('a\\\\;', 'a\\;')
-        self.compare_cleanse([[['a\\;']]], [[['a;']]])
-        self.compare_cleanse(['\\\\', '\\;'], ['\\', ';'])
+        self.compare_cleanse("a", "a")
+        self.compare_cleanse("a\\|", "a|")
+        self.compare_cleanse("a\\;", "a;")
+        self.compare_cleanse("a\\\\", "a\\")
+        self.compare_cleanse("a\\\\;", "a\\;")
+        self.compare_cleanse([[["a\\;"]]], [[["a;"]]])
+        self.compare_cleanse(["\\\\", "\\;"], ["\\", ";"])
 
     def test_split_into_lists(self):
-        self.compare_split_into_lists('1', '1')
-        self.compare_split_into_lists('1;', ['1'])
-        self.compare_split_into_lists('1;2', ['1','2'])
-        self.compare_split_into_lists('1;2;', ['1','2'])
-        self.compare_split_into_lists('1;2;;', ['1','2',''])
-        self.compare_split_into_lists('1;2|', [['1','2']])
-        self.compare_split_into_lists('1;|2;', [['1'],['2']])
-        self.compare_split_into_lists('1;|2', [['1'],'2'])
-        self.compare_split_into_lists('|a', ['', 'a'])
-        self.compare_split_into_lists('a|b', ['a', 'b'])
-        self.compare_split_into_lists('a|b|', ['a', 'b'])
-        self.compare_split_into_lists('a|', ['a'])
-        self.compare_split_into_lists('a\\|', 'a|')
-        self.compare_split_into_lists('a\\;', 'a;')
-        self.compare_split_into_lists('a|\\;', ['a', ';'])
-        self.compare_split_into_lists('a|;', ['a', ['']])
-        self.compare_split_into_lists('1;2|3;4', [['1', '2'], ['3', '4']])
-        self.compare_split_into_lists('1;2|3;4;', [['1', '2'], ['3', '4']])
-        self.compare_split_into_lists('1;2|3;4\\;', [['1', '2'], ['3', '4;']])
-        self.compare_split_into_lists('1;2|3;4\\|', [['1', '2'], ['3', '4|']])
-        self.compare_split_into_lists(CellParser.escape_string('|;;|\\;\\\\\\|'), '|;;|\\;\\\\\\|')
+        self.compare_split_into_lists("1", "1")
+        self.compare_split_into_lists("1;", ["1"])
+        self.compare_split_into_lists("1;2", ["1", "2"])
+        self.compare_split_into_lists("1;2;", ["1", "2"])
+        self.compare_split_into_lists("1;2;;", ["1", "2", ""])
+        self.compare_split_into_lists("1;2|", [["1", "2"]])
+        self.compare_split_into_lists("1;|2;", [["1"], ["2"]])
+        self.compare_split_into_lists("1;|2", [["1"], "2"])
+        self.compare_split_into_lists("|a", ["", "a"])
+        self.compare_split_into_lists("a|b", ["a", "b"])
+        self.compare_split_into_lists("a|b|", ["a", "b"])
+        self.compare_split_into_lists("a|", ["a"])
+        self.compare_split_into_lists("a\\|", "a|")
+        self.compare_split_into_lists("a\\;", "a;")
+        self.compare_split_into_lists("a|\\;", ["a", ";"])
+        self.compare_split_into_lists("a|;", ["a", [""]])
+        self.compare_split_into_lists("1;2|3;4", [["1", "2"], ["3", "4"]])
+        self.compare_split_into_lists("1;2|3;4;", [["1", "2"], ["3", "4"]])
+        self.compare_split_into_lists("1;2|3;4\\;", [["1", "2"], ["3", "4;"]])
+        self.compare_split_into_lists("1;2|3;4\\|", [["1", "2"], ["3", "4|"]])
+        self.compare_split_into_lists(
+            CellParser.escape_string("|;;|\\;\\\\\\|"), "|;;|\\;\\\\\\|"
+        )
 
     def test_string_stripping(self):
-        self.compare_cleanse(' a;\n', 'a;')
-        self.compare_cleanse([' a;\n'], ['a;'])
-        self.compare_split_into_lists(' a\n|\nb ', ['a', 'b'])
-        self.compare_split_into_lists('1; 2\n|\n3; 4', [['1', '2'], ['3', '4']])
+        self.compare_cleanse(" a;\n", "a;")
+        self.compare_cleanse([" a;\n"], ["a;"])
+        self.compare_split_into_lists(" a\n|\nb ", ["a", "b"])
+        self.compare_split_into_lists("1; 2\n|\n3; 4", [["1", "2"], ["3", "4"]])
 
 
 class TestCellParser(unittest.TestCase):
-
     def setUp(self):
         self.parser = CellParser()
 
     def test_parse_as_string(self):
-        out = self.parser.parse_as_string('plain string')
-        self.assertEqual(out, 'plain string')
-        out = self.parser.parse_as_string('{{var}} :)', context={'var' : 15})
-        self.assertEqual(out, '15 :)')
+        out = self.parser.parse_as_string("plain string")
+        self.assertEqual(out, "plain string")
+        out = self.parser.parse_as_string("{{var}} :)", context={"var": 15})
+        self.assertEqual(out, "15 :)")
 
-        instance = OuterModel(strings=['a', 'b'], inner=InnerModel(str_field='xyz'))
-        context = {'instance' : instance}
-        out = self.parser.parse_as_string('{{instance.strings[1]}}', context=context)
-        self.assertEqual(out, 'b')
-        out = self.parser.parse_as_string('{{instance.inner.str_field}}', context=context)
-        self.assertEqual(out, 'xyz')
+        instance = OuterModel(strings=["a", "b"], inner=InnerModel(str_field="xyz"))
+        context = {"instance": instance}
+        out = self.parser.parse_as_string("{{instance.strings[1]}}", context=context)
+        self.assertEqual(out, "b")
+        out = self.parser.parse_as_string(
+            "{{instance.inner.str_field}}", context=context
+        )
+        self.assertEqual(out, "xyz")
 
     def test_parse(self):
-        out = self.parser.parse('a;b;c')
-        self.assertEqual(out, ['a', 'b', 'c'])
+        out = self.parser.parse("a;b;c")
+        self.assertEqual(out, ["a", "b", "c"])
 
-        context = {'list' : ['a', 'b', 'c']}
-        out = self.parser.parse('{% for e in list %}{{e}}{% endfor %}', context=context)
-        self.assertEqual(out, 'abc')
+        context = {"list": ["a", "b", "c"]}
+        out = self.parser.parse("{% for e in list %}{{e}}{% endfor %}", context=context)
+        self.assertEqual(out, "abc")
         # Templating comes first, only then splitting into a list
-        out = self.parser.parse('{% for e in list %}{{e}};{% endfor %}', context=context)
-        self.assertEqual(out, ['a', 'b', 'c'])
+        out = self.parser.parse(
+            "{% for e in list %}{{e}};{% endfor %}", context=context
+        )
+        self.assertEqual(out, ["a", "b", "c"])
 
     def test_escape_filter(self):
         out = self.parser.parse('{{"a;b;c"}}')
-        self.assertEqual(out, ['a', 'b', 'c'])
+        self.assertEqual(out, ["a", "b", "c"])
         out = self.parser.parse('{{"a;b;c"|escape}}')
-        self.assertEqual(out, 'a;b;c')
-        string = '\\|;\\'
-        out = self.parser.parse('{{string|escape}}', context={'string':string})
+        self.assertEqual(out, "a;b;c")
+        string = "\\|;\\"
+        out = self.parser.parse("{{string|escape}}", context={"string": string})
         self.assertEqual(out, string)
 
     def test_parse_native_tpye(self):
         out = self.parser.parse_as_string('{@(1,2,[3,"a"])@}')
-        self.assertEqual(out, (1,2,[3,'a']))
+        self.assertEqual(out, (1, 2, [3, "a"]))
         out = self.parser.parse_as_string('  {@(1,2,[3,"a"])@} ')
-        self.assertEqual(out, (1,2,[3,'a']))
+        self.assertEqual(out, (1, 2, [3, "a"]))
         out = self.parser.parse_as_string('{@ ( 1 , 2 , [ 3 , "a" ] ) @}')
-        self.assertEqual(out, (1,2,[3,'a']))
+        self.assertEqual(out, (1, 2, [3, "a"]))
 
-        instance = OuterModel(strings=['a', 'b'], inner=InnerModel(str_field='xyz'))
-        context = {'instance' : instance}
-        out = self.parser.parse_as_string('{@instance@}', context=context)
+        instance = OuterModel(strings=["a", "b"], inner=InnerModel(str_field="xyz"))
+        context = {"instance": instance}
+        out = self.parser.parse_as_string("{@instance@}", context=context)
         self.assertEqual(out, instance)
-        out = self.parser.parse_as_string('{@instance.inner@}', context=context)
+        out = self.parser.parse_as_string("{@instance.inner@}", context=context)
         self.assertEqual(out, instance.inner)
-        out = self.parser.parse_as_string('{@instance.strings@}', context=context)
-        self.assertEqual(out, ['a', 'b'])
+        out = self.parser.parse_as_string("{@instance.strings@}", context=context)
+        self.assertEqual(out, ["a", "b"])
 
         class TestObj:
             def __init__(self, value):
                 self.value = value
-        test_objs = [TestObj('1'), TestObj('2'), TestObj('A')]
-        out = self.parser.parse_as_string('{@test_objs@}', context={'test_objs' : test_objs})
+
+        test_objs = [TestObj("1"), TestObj("2"), TestObj("A")]
+        out = self.parser.parse_as_string(
+            "{@test_objs@}", context={"test_objs": test_objs}
+        )
         self.assertEqual(out, test_objs)
-        out = self.parser.parse_as_string('{@range(1,5)@}')
-        self.assertEqual(out, range(1,5))
+        out = self.parser.parse_as_string("{@range(1,5)@}")
+        self.assertEqual(out, range(1, 5))

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -7,31 +7,39 @@ from rpft.rapidpro.models.campaigns import Campaign, CampaignEvent
 
 
 def get_flow_with_group_and_flow_node():
-    flow = FlowContainer('Group Flow')
+    flow = FlowContainer("Group Flow")
     node = BasicNode()
-    node.add_action(AddContactGroupAction([Group('No UUID Group'), Group('UUID Group', 'fake-uuid')]))
+    node.add_action(
+        AddContactGroupAction(
+            [Group("No UUID Group"), Group("UUID Group", "fake-uuid")]
+        )
+    )
     flow.add_node(node)
-    flow.add_node(EnterFlowNode('Second Flow'))
+    flow.add_node(EnterFlowNode("Second Flow"))
     return flow
 
+
 def get_has_group_flow():
-    flow = FlowContainer('Second Flow')
-    node = SwitchRouterNode('@contact.groups')
+    flow = FlowContainer("Second Flow")
+    node = SwitchRouterNode("@contact.groups")
     node.add_choice(
-            comparison_variable='@contact.groups', 
-            comparison_type='has_group', 
-            comparison_arguments=[None, 'No UUID Group'], 
-            category_name='No Category Name', 
-            destination_uuid=None)
+        comparison_variable="@contact.groups",
+        comparison_type="has_group",
+        comparison_arguments=[None, "No UUID Group"],
+        category_name="No Category Name",
+        destination_uuid=None,
+    )
     node.add_choice(
-            comparison_variable='@contact.groups', 
-            comparison_type='has_group', 
-            comparison_arguments=[None, 'UUID Group'], 
-            category_name='Category Name', 
-            destination_uuid=None)
+        comparison_variable="@contact.groups",
+        comparison_type="has_group",
+        comparison_arguments=[None, "UUID Group"],
+        category_name="Category Name",
+        destination_uuid=None,
+    )
     flow.add_node(node)
-    flow.add_node(EnterFlowNode('Second Flow'))
+    flow.add_node(EnterFlowNode("Second Flow"))
     return flow
+
 
 class TestRapidProContainer(unittest.TestCase):
     def setUp(self) -> None:
@@ -41,24 +49,24 @@ class TestRapidProContainer(unittest.TestCase):
         rpc = RapidProContainer()
         rpc.add_flow(get_flow_with_group_and_flow_node())
         self.assertIsNone(rpc.flows[0].nodes[0].actions[0].groups[0].uuid)
-        self.assertEqual(rpc.flows[0].nodes[0].actions[0].groups[1].uuid, 'fake-uuid')
+        self.assertEqual(rpc.flows[0].nodes[0].actions[0].groups[1].uuid, "fake-uuid")
         self.assertIsNone(rpc.flows[0].nodes[1].actions[0].flow.uuid)
         rpc.update_global_uuids()
         self.assertIsNotNone(rpc.flows[0].nodes[0].actions[0].groups[0].uuid)
-        self.assertEqual(rpc.flows[0].nodes[0].actions[0].groups[1].uuid, 'fake-uuid')
+        self.assertEqual(rpc.flows[0].nodes[0].actions[0].groups[1].uuid, "fake-uuid")
         self.assertIsNotNone(rpc.flows[0].nodes[1].actions[0].flow.uuid)
 
     def test_assign_group_predefined(self):
-        rpc = RapidProContainer(groups=[Group('No UUID Group', 'ABCD')])
+        rpc = RapidProContainer(groups=[Group("No UUID Group", "ABCD")])
         rpc.add_flow(get_flow_with_group_and_flow_node())
         self.assertIsNone(rpc.flows[0].nodes[0].actions[0].groups[0].uuid)
         rpc.update_global_uuids()
-        self.assertEqual(rpc.flows[0].nodes[0].actions[0].groups[0].uuid, 'ABCD')
+        self.assertEqual(rpc.flows[0].nodes[0].actions[0].groups[0].uuid, "ABCD")
 
     def test_assign_group_clash(self):
-        rpc = RapidProContainer(groups=[Group('UUID Group', 'ABCD')])
+        rpc = RapidProContainer(groups=[Group("UUID Group", "ABCD")])
         rpc.add_flow(get_flow_with_group_and_flow_node())
-        self.assertEqual(rpc.flows[0].nodes[0].actions[0].groups[1].uuid, 'fake-uuid')
+        self.assertEqual(rpc.flows[0].nodes[0].actions[0].groups[1].uuid, "fake-uuid")
         with self.assertRaises(ValueError):
             # ValueError: Group/Flow UUID Group has multiple uuids: fake-uuid and ABCD
             rpc.update_global_uuids()
@@ -69,27 +77,56 @@ class TestRapidProContainer(unittest.TestCase):
         rpc.add_flow(get_has_group_flow())
         rpc.update_global_uuids()
         self.assertEqual(rpc.flows[1].uuid, rpc.flows[0].nodes[1].actions[0].flow.uuid)
-        self.assertEqual(rpc.flows[1].nodes[0].router.cases[0].arguments[0], rpc.flows[0].nodes[0].actions[0].groups[0].uuid)
-        self.assertEqual(rpc.flows[1].nodes[0].router.cases[1].arguments[0], 'fake-uuid')
+        self.assertEqual(
+            rpc.flows[1].nodes[0].router.cases[0].arguments[0],
+            rpc.flows[0].nodes[0].actions[0].groups[0].uuid,
+        )
+        self.assertEqual(
+            rpc.flows[1].nodes[0].router.cases[1].arguments[0], "fake-uuid"
+        )
 
     def test_assign_uuids_to_campaign(self):
         rpc = RapidProContainer()
         rpc.add_flow(get_flow_with_group_and_flow_node())
-        event = CampaignEvent(offset=1234, unit='H', event_type='F', delivery_hour=-1, start_mode='I', relative_to_label='Created On', flow_name='Second Flow')
-        campaign = Campaign("My Campaign", Group('UUID Group'), events=[event])
+        event = CampaignEvent(
+            offset=1234,
+            unit="H",
+            event_type="F",
+            delivery_hour=-1,
+            start_mode="I",
+            relative_to_label="Created On",
+            flow_name="Second Flow",
+        )
+        campaign = Campaign("My Campaign", Group("UUID Group"), events=[event])
         rpc.add_campaign(campaign)
         rpc.update_global_uuids()
-        self.assertEqual(rpc.campaigns[0].group.uuid, 'fake-uuid')
-        self.assertEqual(rpc.campaigns[0].events[0].flow.uuid, rpc.flows[0].nodes[1].actions[0].flow.uuid)
+        self.assertEqual(rpc.campaigns[0].group.uuid, "fake-uuid")
+        self.assertEqual(
+            rpc.campaigns[0].events[0].flow.uuid,
+            rpc.flows[0].nodes[1].actions[0].flow.uuid,
+        )
 
     def test_get_uuids_from_campaign(self):
         rpc = RapidProContainer()
         rpc.add_flow(get_flow_with_group_and_flow_node())
-        event = CampaignEvent(offset=1234, unit='H', event_type='F', delivery_hour=-1, start_mode='I', relative_to_label='Created On', flow_name='Second Flow', flow_uuid='fake-flow-uuid')
-        campaign = Campaign("My Campaign", Group('No UUID Group', 'fake-group-uuid'), events=[event])
+        event = CampaignEvent(
+            offset=1234,
+            unit="H",
+            event_type="F",
+            delivery_hour=-1,
+            start_mode="I",
+            relative_to_label="Created On",
+            flow_name="Second Flow",
+            flow_uuid="fake-flow-uuid",
+        )
+        campaign = Campaign(
+            "My Campaign", Group("No UUID Group", "fake-group-uuid"), events=[event]
+        )
         rpc.add_campaign(campaign)
         rpc.update_global_uuids()
-        self.assertEqual(rpc.campaigns[0].group.uuid, 'fake-group-uuid')
-        self.assertEqual(rpc.flows[0].nodes[0].actions[0].groups[0].uuid, 'fake-group-uuid')
-        self.assertEqual(rpc.flows[0].nodes[1].actions[0].flow.uuid, 'fake-flow-uuid')
-        self.assertEqual(rpc.campaigns[0].events[0].flow.uuid, 'fake-flow-uuid')
+        self.assertEqual(rpc.campaigns[0].group.uuid, "fake-group-uuid")
+        self.assertEqual(
+            rpc.flows[0].nodes[0].actions[0].groups[0].uuid, "fake-group-uuid"
+        )
+        self.assertEqual(rpc.flows[0].nodes[1].actions[0].flow.uuid, "fake-flow-uuid")
+        self.assertEqual(rpc.campaigns[0].events[0].flow.uuid, "fake-flow-uuid")

--- a/tests/test_contentindexparser.py
+++ b/tests/test_contentindexparser.py
@@ -10,476 +10,547 @@ from tests.utils import traverse_flow, Context
 
 
 class TestParsing(unittest.TestCase):
-
     def compare_messages(self, render_output, flow_name, messages_exp, context=None):
         flow_found = False
         for flow in render_output["flows"]:
             if flow["name"] == flow_name:
                 flow_found = True
                 actions = traverse_flow(flow, context or Context())
-                actions_exp = list(zip(['send_msg']*len(messages_exp), messages_exp))
+                actions_exp = list(zip(["send_msg"] * len(messages_exp), messages_exp))
                 self.assertEqual(actions, actions_exp)
         if not flow_found:
-            self.assertTrue(False, msg=f'Flow with name "{flow_name}" does not exist in output.')
+            self.assertTrue(
+                False, msg=f'Flow with name "{flow_name}" does not exist in output.'
+            )
 
     def get_flow_names(self, render_output):
         return {flow["name"] for flow in render_output["flows"]}
 
     def test_basic_template_definition(self):
         ci_sheet = (
-            'type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n'
-            'template_definition,my_template,,,,,\n'
-            'template_definition,my_template2,,,,,draft\n'
+            "type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n"
+            "template_definition,my_template,,,,,\n"
+            "template_definition,my_template2,,,,,draft\n"
         )
         my_template = (
-            'row_id,type,from,message_text\n'
-            ',send_message,start,Some text\n'
+            "row_id,type,from,message_text\n" ",send_message,start,Some text\n"
         )
 
-        sheet_reader = MockSheetReader(ci_sheet, {'my_template' : my_template})
+        sheet_reader = MockSheetReader(ci_sheet, {"my_template": my_template})
         ci_parser = ContentIndexParser(sheet_reader)
-        template_sheet = ci_parser.get_template_sheet('my_template')
-        self.assertEqual(template_sheet.table[0][1], 'send_message')
-        self.assertEqual(template_sheet.table[0][3], 'Some text')
+        template_sheet = ci_parser.get_template_sheet("my_template")
+        self.assertEqual(template_sheet.table[0][1], "send_message")
+        self.assertEqual(template_sheet.table[0][3], "Some text")
         with self.assertRaises(KeyError):
-            ci_parser.get_template_sheet('my_template2')
+            ci_parser.get_template_sheet("my_template2")
 
     def test_basic_nesting(self):
         ci_sheet = (
-            'type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n'
-            'template_definition,my_template,,,,,\n'
-            'content_index,ci_sheet2,,,,,\n'
+            "type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n"
+            "template_definition,my_template,,,,,\n"
+            "content_index,ci_sheet2,,,,,\n"
         )
         ci_sheet2 = (
-            'type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n'
-            'template_definition,my_template2,,,,,\n'
+            "type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n"
+            "template_definition,my_template2,,,,,\n"
         )
         my_template = (
-            'row_id,type,from,message_text\n'
-            ',send_message,start,Some text\n'
+            "row_id,type,from,message_text\n" ",send_message,start,Some text\n"
         )
         my_template2 = (
-            'row_id,type,from,message_text\n'
-            ',send_message,start,Other text\n'
+            "row_id,type,from,message_text\n" ",send_message,start,Other text\n"
         )
         sheet_dict = {
-            'ci_sheet2' : ci_sheet2,
-            'my_template' : my_template,
-            'my_template2' : my_template2,
+            "ci_sheet2": ci_sheet2,
+            "my_template": my_template,
+            "my_template2": my_template2,
         }
 
         sheet_reader = MockSheetReader(ci_sheet, sheet_dict)
         ci_parser = ContentIndexParser(sheet_reader)
-        template_sheet = ci_parser.get_template_sheet('my_template')
-        self.assertEqual(template_sheet.table[0][3], 'Some text')
-        template_sheet = ci_parser.get_template_sheet('my_template2')
-        self.assertEqual(template_sheet.table[0][3], 'Other text')
+        template_sheet = ci_parser.get_template_sheet("my_template")
+        self.assertEqual(template_sheet.table[0][3], "Some text")
+        template_sheet = ci_parser.get_template_sheet("my_template2")
+        self.assertEqual(template_sheet.table[0][3], "Other text")
 
     def test_basic_user_model(self):
         ci_sheet = (
-            'type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n'
-            'data_sheet,simpledata,,,,SimpleRowModel,\n'
+            "type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n"
+            "data_sheet,simpledata,,,,SimpleRowModel,\n"
         )
-        simpledata = (
-            'ID,value1,value2\n'
-            'rowA,1A,2A\n'
-            'rowB,1B,2B\n'
-        )
+        simpledata = "ID,value1,value2\n" "rowA,1A,2A\n" "rowB,1B,2B\n"
 
-        sheet_reader = MockSheetReader(ci_sheet, {'simpledata' : simpledata})
-        ci_parser = ContentIndexParser(sheet_reader, 'tests.datarowmodels.simplemodel')
-        datamodelA = ci_parser.get_data_model_instance('simpledata', 'rowA')
-        datamodelB = ci_parser.get_data_model_instance('simpledata', 'rowB')
-        self.assertEqual(datamodelA.value1, '1A')
-        self.assertEqual(datamodelA.value2, '2A')
-        self.assertEqual(datamodelB.value1, '1B')
-        self.assertEqual(datamodelB.value2, '2B')
+        sheet_reader = MockSheetReader(ci_sheet, {"simpledata": simpledata})
+        ci_parser = ContentIndexParser(sheet_reader, "tests.datarowmodels.simplemodel")
+        datamodelA = ci_parser.get_data_model_instance("simpledata", "rowA")
+        datamodelB = ci_parser.get_data_model_instance("simpledata", "rowB")
+        self.assertEqual(datamodelA.value1, "1A")
+        self.assertEqual(datamodelA.value2, "2A")
+        self.assertEqual(datamodelB.value1, "1B")
+        self.assertEqual(datamodelB.value2, "2B")
 
     def test_concat(self):
         ci_sheet = (
-            'type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n'
-            'data_sheet,simpleA;simpleB,,,simpledata,SimpleRowModel,\n'
+            "type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n"
+            "data_sheet,simpleA;simpleB,,,simpledata,SimpleRowModel,\n"
         )
-        simpleA = (
-            'ID,value1,value2\n'
-            'rowA,1A,2A\n'
-        )
-        simpleB = (
-            'ID,value1,value2\n'
-            'rowB,1B,2B\n'
-        )
+        simpleA = "ID,value1,value2\n" "rowA,1A,2A\n"
+        simpleB = "ID,value1,value2\n" "rowB,1B,2B\n"
         sheet_dict = {
-            'simpleA' : simpleA,
-            'simpleB' : simpleB,
+            "simpleA": simpleA,
+            "simpleB": simpleB,
         }
 
         sheet_reader = MockSheetReader(ci_sheet, sheet_dict)
-        ci_parser = ContentIndexParser(sheet_reader, 'tests.datarowmodels.simplemodel')
-        datamodelA = ci_parser.get_data_model_instance('simpledata', 'rowA')
-        datamodelB = ci_parser.get_data_model_instance('simpledata', 'rowB')
-        self.assertEqual(datamodelA.value1, '1A')
-        self.assertEqual(datamodelA.value2, '2A')
-        self.assertEqual(datamodelB.value1, '1B')
-        self.assertEqual(datamodelB.value2, '2B')
+        ci_parser = ContentIndexParser(sheet_reader, "tests.datarowmodels.simplemodel")
+        datamodelA = ci_parser.get_data_model_instance("simpledata", "rowA")
+        datamodelB = ci_parser.get_data_model_instance("simpledata", "rowB")
+        self.assertEqual(datamodelA.value1, "1A")
+        self.assertEqual(datamodelA.value2, "2A")
+        self.assertEqual(datamodelB.value1, "1B")
+        self.assertEqual(datamodelB.value2, "2B")
 
     def test_generate_flows(self):
         ci_sheet = (
-            'type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n'
-            'create_flow,my_template,nesteddata,row1,,,\n'
-            'create_flow,my_template,nesteddata,row2,,,\n'
-            'create_flow,my_basic_flow,,,,,\n'
-            'data_sheet,nesteddata,,,,NestedRowModel,\n'
+            "type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n"
+            "create_flow,my_template,nesteddata,row1,,,\n"
+            "create_flow,my_template,nesteddata,row2,,,\n"
+            "create_flow,my_basic_flow,,,,,\n"
+            "data_sheet,nesteddata,,,,NestedRowModel,\n"
         )
         # The templates are instantiated implicitly with all data rows
         ci_sheet_alt = (
-            'type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n'
-            'create_flow,my_template,nesteddata,,,,\n'
-            'create_flow,my_basic_flow,,,,,\n'
-            'data_sheet,nesteddata,,,,NestedRowModel,\n'
+            "type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n"
+            "create_flow,my_template,nesteddata,,,,\n"
+            "create_flow,my_basic_flow,,,,,\n"
+            "data_sheet,nesteddata,,,,NestedRowModel,\n"
         )
         nesteddata = (
-            'ID,value1,custom_field.happy,custom_field.sad\n'
-            'row1,Value1,Happy1,Sad1\n'
-            'row2,Value2,Happy2,Sad2\n'
-            'row3,Value3,Happy3,Sad3\n'
+            "ID,value1,custom_field.happy,custom_field.sad\n"
+            "row1,Value1,Happy1,Sad1\n"
+            "row2,Value2,Happy2,Sad2\n"
+            "row3,Value3,Happy3,Sad3\n"
         )
         my_template = (
-            'row_id,type,from,message_text\n'
-            ',send_message,start,{{value1}}\n'
-            ',send_message,,{{custom_field.happy}} and {{custom_field.sad}}\n'
+            "row_id,type,from,message_text\n"
+            ",send_message,start,{{value1}}\n"
+            ",send_message,,{{custom_field.happy}} and {{custom_field.sad}}\n"
         )
         my_basic_flow = (
-            'row_id,type,from,message_text\n'
-            ',send_message,start,Some text\n'
+            "row_id,type,from,message_text\n" ",send_message,start,Some text\n"
         )
         sheet_dict = {
-            'nesteddata' : nesteddata,
-            'my_template' : my_template,
-            'my_basic_flow' : my_basic_flow,
+            "nesteddata": nesteddata,
+            "my_template": my_template,
+            "my_basic_flow": my_basic_flow,
         }
 
         sheet_reader = MockSheetReader(ci_sheet, sheet_dict)
-        ci_parser = ContentIndexParser(sheet_reader, 'tests.datarowmodels.nestedmodel')
+        ci_parser = ContentIndexParser(sheet_reader, "tests.datarowmodels.nestedmodel")
         container = ci_parser.parse_all()
         render_output = container.render()
-        self.compare_messages(render_output, 'my_basic_flow', ['Some text'])
-        self.compare_messages(render_output, 'my_template - row1', ['Value1', 'Happy1 and Sad1'])
-        self.compare_messages(render_output, 'my_template - row2', ['Value2', 'Happy2 and Sad2'])
+        self.compare_messages(render_output, "my_basic_flow", ["Some text"])
+        self.compare_messages(
+            render_output, "my_template - row1", ["Value1", "Happy1 and Sad1"]
+        )
+        self.compare_messages(
+            render_output, "my_template - row2", ["Value2", "Happy2 and Sad2"]
+        )
 
         sheet_reader = MockSheetReader(ci_sheet_alt, sheet_dict)
-        ci_parser = ContentIndexParser(sheet_reader, 'tests.datarowmodels.nestedmodel')
+        ci_parser = ContentIndexParser(sheet_reader, "tests.datarowmodels.nestedmodel")
         container = ci_parser.parse_all()
         render_output = container.render()
-        self.compare_messages(render_output, 'my_basic_flow', ['Some text'])
-        self.compare_messages(render_output, 'my_template - row1', ['Value1', 'Happy1 and Sad1'])
-        self.compare_messages(render_output, 'my_template - row2', ['Value2', 'Happy2 and Sad2'])
-        self.compare_messages(render_output, 'my_template - row3', ['Value3', 'Happy3 and Sad3'])
+        self.compare_messages(render_output, "my_basic_flow", ["Some text"])
+        self.compare_messages(
+            render_output, "my_template - row1", ["Value1", "Happy1 and Sad1"]
+        )
+        self.compare_messages(
+            render_output, "my_template - row2", ["Value2", "Happy2 and Sad2"]
+        )
+        self.compare_messages(
+            render_output, "my_template - row3", ["Value3", "Happy3 and Sad3"]
+        )
 
     def test_bulk_flows_with_args(self):
         ci_sheet = (
-            'type,sheet_name,data_sheet,data_row_id,template_arguments,new_name,data_model,status\n'
-            'template_definition,my_template,,,arg1;arg2,,,\n'
-            'create_flow,my_template,nesteddata,,ARG1;ARG2,my_renamed_template,,\n'
-            'data_sheet,nesteddata,,,,,NestedRowModel,\n'
+            "type,sheet_name,data_sheet,data_row_id,template_arguments,new_name,data_model,status\n"
+            "template_definition,my_template,,,arg1;arg2,,,\n"
+            "create_flow,my_template,nesteddata,,ARG1;ARG2,my_renamed_template,,\n"
+            "data_sheet,nesteddata,,,,,NestedRowModel,\n"
         )
         nesteddata = (
-            'ID,value1,custom_field.happy,custom_field.sad\n'
-            'row1,Value1,Happy1,Sad1\n'
-            'row2,Value2,Happy2,Sad2\n'
+            "ID,value1,custom_field.happy,custom_field.sad\n"
+            "row1,Value1,Happy1,Sad1\n"
+            "row2,Value2,Happy2,Sad2\n"
         )
         my_template = (
-            'row_id,type,from,message_text\n'
-            ',send_message,start,{{value1}} {{arg1}} {{arg2}}\n'
-            ',send_message,,{{custom_field.happy}} and {{custom_field.sad}}\n'
+            "row_id,type,from,message_text\n"
+            ",send_message,start,{{value1}} {{arg1}} {{arg2}}\n"
+            ",send_message,,{{custom_field.happy}} and {{custom_field.sad}}\n"
         )
         sheet_dict = {
-            'nesteddata' : nesteddata,
-            'my_template' : my_template,
+            "nesteddata": nesteddata,
+            "my_template": my_template,
         }
 
         sheet_reader = MockSheetReader(ci_sheet, sheet_dict)
-        ci_parser = ContentIndexParser(sheet_reader, 'tests.datarowmodels.nestedmodel')
+        ci_parser = ContentIndexParser(sheet_reader, "tests.datarowmodels.nestedmodel")
         container = ci_parser.parse_all()
         render_output = container.render()
-        self.compare_messages(render_output, 'my_renamed_template - row1', ['Value1 ARG1 ARG2', 'Happy1 and Sad1'])
-        self.compare_messages(render_output, 'my_renamed_template - row2', ['Value2 ARG1 ARG2', 'Happy2 and Sad2'])
+        self.compare_messages(
+            render_output,
+            "my_renamed_template - row1",
+            ["Value1 ARG1 ARG2", "Happy1 and Sad1"],
+        )
+        self.compare_messages(
+            render_output,
+            "my_renamed_template - row2",
+            ["Value2 ARG1 ARG2", "Happy2 and Sad2"],
+        )
 
     def test_insert_as_block(self):
         ci_sheet = (
-            'type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n'
-            'template_definition,my_template,,,,,\n'
-            'create_flow,my_basic_flow,,,my_renamed_basic_flow,,\n'
-            'data_sheet,nesteddata,,,,NestedRowModel,\n'
+            "type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n"
+            "template_definition,my_template,,,,,\n"
+            "create_flow,my_basic_flow,,,my_renamed_basic_flow,,\n"
+            "data_sheet,nesteddata,,,,NestedRowModel,\n"
         )
         nesteddata = (
-            'ID,value1,custom_field.happy,custom_field.sad\n'
-            'row1,Value1,Happy1,Sad1\n'
-            'row2,Value2,Happy2,Sad2\n'
+            "ID,value1,custom_field.happy,custom_field.sad\n"
+            "row1,Value1,Happy1,Sad1\n"
+            "row2,Value2,Happy2,Sad2\n"
         )
         my_template = (
-            'row_id,type,from,condition,message_text\n'
-            ',send_message,start,,{{value1}}\n'
-            '1,wait_for_response,,,\n'
-            ',send_message,1,happy,I\'m {{custom_field.happy}}\n'
-            ',send_message,1,sad,I\'m {{custom_field.sad}}\n'
-            ',hard_exit,,,\n'
-            ',send_message,1,,I\'m something\n'
+            "row_id,type,from,condition,message_text\n"
+            ",send_message,start,,{{value1}}\n"
+            "1,wait_for_response,,,\n"
+            ",send_message,1,happy,I'm {{custom_field.happy}}\n"
+            ",send_message,1,sad,I'm {{custom_field.sad}}\n"
+            ",hard_exit,,,\n"
+            ",send_message,1,,I'm something\n"
         )
         my_basic_flow = (
-            'row_id,type,from,message_text,data_sheet,data_row_id\n'
-            ',send_message,start,Some text,,\n'
-            '1,insert_as_block,,my_template,nesteddata,row1\n'
-            ',send_message,,Next message 1,,\n'
-            ',insert_as_block,,my_template,nesteddata,row2\n'
-            ',send_message,,Next message 2,,\n'
-            ',go_to,,1,,\n'
+            "row_id,type,from,message_text,data_sheet,data_row_id\n"
+            ",send_message,start,Some text,,\n"
+            "1,insert_as_block,,my_template,nesteddata,row1\n"
+            ",send_message,,Next message 1,,\n"
+            ",insert_as_block,,my_template,nesteddata,row2\n"
+            ",send_message,,Next message 2,,\n"
+            ",go_to,,1,,\n"
         )
         sheet_dict = {
-            'nesteddata' : nesteddata,
-            'my_template' : my_template,
-            'my_basic_flow' : my_basic_flow,
+            "nesteddata": nesteddata,
+            "my_template": my_template,
+            "my_basic_flow": my_basic_flow,
         }
 
         sheet_reader = MockSheetReader(ci_sheet, sheet_dict)
-        ci_parser = ContentIndexParser(sheet_reader, 'tests.datarowmodels.nestedmodel')
+        ci_parser = ContentIndexParser(sheet_reader, "tests.datarowmodels.nestedmodel")
         container = ci_parser.parse_all()
         render_output = container.render()
         messages_exp = [
-            'Some text',
-            'Value1',
+            "Some text",
+            "Value1",
             "I'm Happy1",
-            'Next message 1',
-            'Value2',
+            "Next message 1",
+            "Value2",
             "I'm something",
-            'Next message 2',
-            'Value1',
+            "Next message 2",
+            "Value1",
             "I'm Sad1",  # we're taking the hard exit now, leaving the flow.
         ]
-        self.compare_messages(render_output, 'my_renamed_basic_flow', messages_exp, Context(inputs=['happy', 'else', 'sad']))
+        self.compare_messages(
+            render_output,
+            "my_renamed_basic_flow",
+            messages_exp,
+            Context(inputs=["happy", "else", "sad"]),
+        )
 
     def test_insert_as_block_with_sheet_arguments(self):
         ci_sheet = (
-            'type,sheet_name,data_sheet,data_row_id,template_arguments,new_name,data_model,status\n'
-            'template_definition,my_template,,,lookup;sheet|,,,\n'
-            'create_flow,my_template,nesteddata,row3,string_lookup,,,\n'
-            'create_flow,my_basic_flow,,,,,,\n'
-            'data_sheet,nesteddata,,,,,ListRowModel,\n'
-            'data_sheet,string_lookup,,,,,LookupRowModel,\n'
+            "type,sheet_name,data_sheet,data_row_id,template_arguments,new_name,data_model,status\n"
+            "template_definition,my_template,,,lookup;sheet|,,,\n"
+            "create_flow,my_template,nesteddata,row3,string_lookup,,,\n"
+            "create_flow,my_basic_flow,,,,,,\n"
+            "data_sheet,nesteddata,,,,,ListRowModel,\n"
+            "data_sheet,string_lookup,,,,,LookupRowModel,\n"
         )
         nesteddata = (
-            'ID,messages.1,messages.2\n'
-            'row1,hello,nicetosee\n'
-            'row2,nicetosee,bye\n'
-            'row3,hello,bye\n'
+            "ID,messages.1,messages.2\n"
+            "row1,hello,nicetosee\n"
+            "row2,nicetosee,bye\n"
+            "row3,hello,bye\n"
         )
         string_lookup = (
-            'ID,happy,sad,neutral\n'
-            'hello,Hello :),Hello :(,Hello\n'
-            'bye,Bye :),Bye :(,Bye\n'
-            'nicetosee,Nice to see you :),Not nice to see you :(,Nice to see you\n'
+            "ID,happy,sad,neutral\n"
+            "hello,Hello :),Hello :(,Hello\n"
+            "bye,Bye :),Bye :(,Bye\n"
+            "nicetosee,Nice to see you :),Not nice to see you :(,Nice to see you\n"
         )
         my_template = (
-            'row_id,type,from,condition,message_text\n'
-            '1,split_by_value,,,@field.mood\n'
-            ',send_message,1,happy,{% for msg in messages %}{{lookup[msg].happy}}{% endfor %}\n'
-            ',send_message,1,sad,{% for msg in messages %}{{lookup[msg].sad}}{% endfor %}\n'
-            ',send_message,1,,{% for msg in messages %}{{lookup[msg].neutral}}{% endfor %}\n'
+            "row_id,type,from,condition,message_text\n"
+            "1,split_by_value,,,@field.mood\n"
+            ",send_message,1,happy,{% for msg in messages %}{{lookup[msg].happy}}{% endfor %}\n"
+            ",send_message,1,sad,{% for msg in messages %}{{lookup[msg].sad}}{% endfor %}\n"
+            ",send_message,1,,{% for msg in messages %}{{lookup[msg].neutral}}{% endfor %}\n"
         )
         my_basic_flow = (
-            'row_id,type,from,message_text,data_sheet,data_row_id,template_arguments\n'
-            ',send_message,start,Some text,,,\n'
-            ',insert_as_block,,my_template,nesteddata,row1,string_lookup\n'
-            ',send_message,,Intermission,,,\n'
-            ',insert_as_block,,my_template,nesteddata,row2,string_lookup\n'
+            "row_id,type,from,message_text,data_sheet,data_row_id,template_arguments\n"
+            ",send_message,start,Some text,,,\n"
+            ",insert_as_block,,my_template,nesteddata,row1,string_lookup\n"
+            ",send_message,,Intermission,,,\n"
+            ",insert_as_block,,my_template,nesteddata,row2,string_lookup\n"
         )
         sheet_dict = {
-            'nesteddata' : nesteddata,
-            'my_template' : my_template,
-            'my_basic_flow' : my_basic_flow,
-            'string_lookup' : string_lookup,
+            "nesteddata": nesteddata,
+            "my_template": my_template,
+            "my_basic_flow": my_basic_flow,
+            "string_lookup": string_lookup,
         }
 
         sheet_reader = MockSheetReader(ci_sheet, sheet_dict)
-        ci_parser = ContentIndexParser(sheet_reader, 'tests.datarowmodels.listmodel')
+        ci_parser = ContentIndexParser(sheet_reader, "tests.datarowmodels.listmodel")
         container = ci_parser.parse_all()
         render_output = container.render()
         messages_exp = [
-            'Some text',
-            'Hello :)Nice to see you :)',
-            'Intermission',
-            'Nice to see you :)Bye :)',
+            "Some text",
+            "Hello :)Nice to see you :)",
+            "Intermission",
+            "Nice to see you :)Bye :)",
         ]
-        self.compare_messages(render_output, 'my_basic_flow', messages_exp, Context(variables={'@field.mood':'happy'}))
+        self.compare_messages(
+            render_output,
+            "my_basic_flow",
+            messages_exp,
+            Context(variables={"@field.mood": "happy"}),
+        )
         messages_exp = [
-            'Some text',
-            'Hello :(Not nice to see you :(',
-            'Intermission',
-            'Not nice to see you :(Bye :(',
+            "Some text",
+            "Hello :(Not nice to see you :(",
+            "Intermission",
+            "Not nice to see you :(Bye :(",
         ]
-        self.compare_messages(render_output, 'my_basic_flow', messages_exp, Context(variables={'@field.mood':'sad'}))
+        self.compare_messages(
+            render_output,
+            "my_basic_flow",
+            messages_exp,
+            Context(variables={"@field.mood": "sad"}),
+        )
         messages_exp = [
-            'Some text',
-            'HelloNice to see you',
-            'Intermission',
-            'Nice to see youBye',
+            "Some text",
+            "HelloNice to see you",
+            "Intermission",
+            "Nice to see youBye",
         ]
-        self.compare_messages(render_output, 'my_basic_flow', messages_exp, Context(variables={'@field.mood':'something else'}))
+        self.compare_messages(
+            render_output,
+            "my_basic_flow",
+            messages_exp,
+            Context(variables={"@field.mood": "something else"}),
+        )
 
         messages_exp = [
-            'Hello :)Bye :)',
+            "Hello :)Bye :)",
         ]
-        self.compare_messages(render_output, 'my_template - row3', messages_exp, Context(variables={'@field.mood':'happy'}))
-
+        self.compare_messages(
+            render_output,
+            "my_template - row3",
+            messages_exp,
+            Context(variables={"@field.mood": "happy"}),
+        )
 
     def test_insert_as_block_with_arguments(self):
         ci_sheet = (
-            'type,sheet_name,data_sheet,data_row_id,template_arguments,new_name,data_model,status\n'
-            'template_definition,my_template,,,arg1|arg2;;default2,,,\n'
-            'create_flow,my_template,,,value1,my_template_default,,\n'
-            'create_flow,my_template,,,value1;value2,my_template_explicit,,\n'
+            "type,sheet_name,data_sheet,data_row_id,template_arguments,new_name,data_model,status\n"
+            "template_definition,my_template,,,arg1|arg2;;default2,,,\n"
+            "create_flow,my_template,,,value1,my_template_default,,\n"
+            "create_flow,my_template,,,value1;value2,my_template_explicit,,\n"
         )
         my_template = (
-            'row_id,type,from,condition,message_text\n'
-            ',send_message,,,{{arg1}} {{arg2}}\n'
+            "row_id,type,from,condition,message_text\n"
+            ",send_message,,,{{arg1}} {{arg2}}\n"
         )
         sheet_dict = {
-            'my_template' : my_template,
+            "my_template": my_template,
         }
 
         sheet_reader = MockSheetReader(ci_sheet, sheet_dict)
-        ci_parser = ContentIndexParser(sheet_reader, 'tests.datarowmodels.listmodel')
+        ci_parser = ContentIndexParser(sheet_reader, "tests.datarowmodels.listmodel")
         container = ci_parser.parse_all()
         render_output = container.render()
         messages_exp = [
-            'value1 default2',
+            "value1 default2",
         ]
-        self.compare_messages(render_output, 'my_template_default', messages_exp)
+        self.compare_messages(render_output, "my_template_default", messages_exp)
         messages_exp = [
-            'value1 value2',
+            "value1 value2",
         ]
-        self.compare_messages(render_output, 'my_template_explicit', messages_exp)
-
+        self.compare_messages(render_output, "my_template_explicit", messages_exp)
 
     def test_eval(self):
         ci_sheet = (
-            'type,sheet_name,data_sheet,data_row_id,new_name,data_model,template_arguments,status\n'
-            'template_definition,flow,,,,,metadata;sheet|,\n'
-            'data_sheet,content,,,,EvalContentModel,,\n'
-            'data_sheet,metadata,,,,EvalMetadataModel,,\n'
-            'create_flow,flow,content,,,,metadata,\n'
+            "type,sheet_name,data_sheet,data_row_id,new_name,data_model,template_arguments,status\n"
+            "template_definition,flow,,,,,metadata;sheet|,\n"
+            "data_sheet,content,,,,EvalContentModel,,\n"
+            "data_sheet,metadata,,,,EvalMetadataModel,,\n"
+            "create_flow,flow,content,,,,metadata,\n"
         )
-        metadata = (
-            'ID,include_if\n'
-            'a,text\n'
-        )
+        metadata = "ID,include_if\n" "a,text\n"
         flow = (
             '"row_id","type","from","loop_variable","include_if","message_text"\n'
             ',"send_message",,,,"hello"\n'
             ',"send_message",,,"{@metadata[""a""].include_if|eval == ""yes""@}","{{text}}"\n'
         )
-        content = (
-            'ID,text\n'
-            'id1,yes\n'
-            'id2,no\n'
-        )
+        content = "ID,text\n" "id1,yes\n" "id2,no\n"
         sheet_dict = {
-            'metadata' : metadata,
-            'content' : content,
-            'flow' : flow,
+            "metadata": metadata,
+            "content": content,
+            "flow": flow,
         }
 
         sheet_reader = MockSheetReader(ci_sheet, sheet_dict)
-        ci_parser = ContentIndexParser(sheet_reader, 'tests.datarowmodels.evalmodels')
+        ci_parser = ContentIndexParser(sheet_reader, "tests.datarowmodels.evalmodels")
         container = ci_parser.parse_all()
         render_output = container.render()
         messages_exp = [
-            'hello', 'yes',
+            "hello",
+            "yes",
         ]
-        self.compare_messages(render_output, 'flow - id1', messages_exp)
+        self.compare_messages(render_output, "flow - id1", messages_exp)
         messages_exp = [
-            'hello',
+            "hello",
         ]
-        self.compare_messages(render_output, 'flow - id2', messages_exp)
-
+        self.compare_messages(render_output, "flow - id2", messages_exp)
 
     def test_tags(self):
         ci_sheet = (
-            'type,sheet_name,new_name,template_arguments,tags.1,tags.2\n'
-            'template_definition,flow,,arg,,\n'
-            'create_flow,flow,flow-world,World,,\n'
-            'create_flow,flow,flow-t1,Tag1Only,tag1,\n'
-            'create_flow,flow,flow-b1,Bag1Only,bag1,\n'
-            'create_flow,flow,flow-t2,Tag2Only,,tag2\n'
-            'create_flow,flow,flow-b2,Bag2Only,,bag2\n'
-            'create_flow,flow,flow-t1t2,Tag1Tag2,tag1,tag2\n'
-            'create_flow,flow,flow-t1b2,Tag1Bag2,tag1,bag2\n'
-            'create_flow,flow,flow-b1t2,Bag1Tag2,bag1,tag2\n'
+            "type,sheet_name,new_name,template_arguments,tags.1,tags.2\n"
+            "template_definition,flow,,arg,,\n"
+            "create_flow,flow,flow-world,World,,\n"
+            "create_flow,flow,flow-t1,Tag1Only,tag1,\n"
+            "create_flow,flow,flow-b1,Bag1Only,bag1,\n"
+            "create_flow,flow,flow-t2,Tag2Only,,tag2\n"
+            "create_flow,flow,flow-b2,Bag2Only,,bag2\n"
+            "create_flow,flow,flow-t1t2,Tag1Tag2,tag1,tag2\n"
+            "create_flow,flow,flow-t1b2,Tag1Bag2,tag1,bag2\n"
+            "create_flow,flow,flow-b1t2,Bag1Tag2,bag1,tag2\n"
         )
         flow = (
             '"row_id","type","from","loop_variable","include_if","message_text"\n'
             ',"send_message",,,,"Hello {{arg}}"\n'
         )
         sheet_dict = {
-            'flow' : flow,
+            "flow": flow,
         }
 
         sheet_reader = MockSheetReader(ci_sheet, sheet_dict)
-        ci_parser = ContentIndexParser(sheet_reader, 'tests.datarowmodels.evalmodels')
+        ci_parser = ContentIndexParser(sheet_reader, "tests.datarowmodels.evalmodels")
         container = ci_parser.parse_all()
         render_output = container.render()
-        self.assertEqual(self.get_flow_names(render_output), {"flow-world", "flow-t1", "flow-b1", "flow-t2", "flow-b2", "flow-t1t2", "flow-t1b2", "flow-b1t2"})
-        self.compare_messages(render_output, 'flow-world', ['Hello World'])
-        self.compare_messages(render_output, 'flow-t1', ['Hello Tag1Only'])
-        self.compare_messages(render_output, 'flow-b1', ['Hello Bag1Only'])
-        self.compare_messages(render_output, 'flow-t2', ['Hello Tag2Only'])
-        self.compare_messages(render_output, 'flow-b2', ['Hello Bag2Only'])
-        self.compare_messages(render_output, 'flow-t1t2', ['Hello Tag1Tag2'])
-        self.compare_messages(render_output, 'flow-t1b2', ['Hello Tag1Bag2'])
-        self.compare_messages(render_output, 'flow-b1t2', ['Hello Bag1Tag2'])
+        self.assertEqual(
+            self.get_flow_names(render_output),
+            {
+                "flow-world",
+                "flow-t1",
+                "flow-b1",
+                "flow-t2",
+                "flow-b2",
+                "flow-t1t2",
+                "flow-t1b2",
+                "flow-b1t2",
+            },
+        )
+        self.compare_messages(render_output, "flow-world", ["Hello World"])
+        self.compare_messages(render_output, "flow-t1", ["Hello Tag1Only"])
+        self.compare_messages(render_output, "flow-b1", ["Hello Bag1Only"])
+        self.compare_messages(render_output, "flow-t2", ["Hello Tag2Only"])
+        self.compare_messages(render_output, "flow-b2", ["Hello Bag2Only"])
+        self.compare_messages(render_output, "flow-t1t2", ["Hello Tag1Tag2"])
+        self.compare_messages(render_output, "flow-t1b2", ["Hello Tag1Bag2"])
+        self.compare_messages(render_output, "flow-b1t2", ["Hello Bag1Tag2"])
 
         tag_matcher = TagMatcher(["1", "tag1"])
-        ci_parser = ContentIndexParser(sheet_reader, 'tests.datarowmodels.evalmodels', tag_matcher)
+        ci_parser = ContentIndexParser(
+            sheet_reader, "tests.datarowmodels.evalmodels", tag_matcher
+        )
         container = ci_parser.parse_all()
         render_output = container.render()
-        self.assertEqual(self.get_flow_names(render_output), {"flow-world", "flow-t1", "flow-t2", "flow-b2", "flow-t1t2", "flow-t1b2"})
+        self.assertEqual(
+            self.get_flow_names(render_output),
+            {"flow-world", "flow-t1", "flow-t2", "flow-b2", "flow-t1t2", "flow-t1b2"},
+        )
 
         tag_matcher = TagMatcher(["1", "tag1", "bag1"])
-        ci_parser = ContentIndexParser(sheet_reader, 'tests.datarowmodels.evalmodels', tag_matcher)
+        ci_parser = ContentIndexParser(
+            sheet_reader, "tests.datarowmodels.evalmodels", tag_matcher
+        )
         container = ci_parser.parse_all()
         render_output = container.render()
-        self.assertEqual(self.get_flow_names(render_output), {"flow-world", "flow-t1", "flow-b1", "flow-t2", "flow-b2", "flow-t1t2", "flow-t1b2", "flow-b1t2"})
+        self.assertEqual(
+            self.get_flow_names(render_output),
+            {
+                "flow-world",
+                "flow-t1",
+                "flow-b1",
+                "flow-t2",
+                "flow-b2",
+                "flow-t1t2",
+                "flow-t1b2",
+                "flow-b1t2",
+            },
+        )
 
         tag_matcher = TagMatcher(["1", "tag1", "2", "tag2"])
-        ci_parser = ContentIndexParser(sheet_reader, 'tests.datarowmodels.evalmodels', tag_matcher)
+        ci_parser = ContentIndexParser(
+            sheet_reader, "tests.datarowmodels.evalmodels", tag_matcher
+        )
         container = ci_parser.parse_all()
         render_output = container.render()
-        self.assertEqual(self.get_flow_names(render_output), {"flow-world", "flow-t1","flow-t2","flow-t1t2"})
+        self.assertEqual(
+            self.get_flow_names(render_output),
+            {"flow-world", "flow-t1", "flow-t2", "flow-t1t2"},
+        )
 
         tag_matcher = TagMatcher(["5", "tag1", "bag1"])
-        ci_parser = ContentIndexParser(sheet_reader, 'tests.datarowmodels.evalmodels', tag_matcher)
+        ci_parser = ContentIndexParser(
+            sheet_reader, "tests.datarowmodels.evalmodels", tag_matcher
+        )
         container = ci_parser.parse_all()
         render_output = container.render()
-        self.assertEqual(self.get_flow_names(render_output), {"flow-world", "flow-t1", "flow-b1", "flow-t2", "flow-b2", "flow-t1t2", "flow-t1b2", "flow-b1t2"})
+        self.assertEqual(
+            self.get_flow_names(render_output),
+            {
+                "flow-world",
+                "flow-t1",
+                "flow-b1",
+                "flow-t2",
+                "flow-b2",
+                "flow-t1t2",
+                "flow-t1b2",
+                "flow-b1t2",
+            },
+        )
 
 
 class TestParseCampaigns(unittest.TestCase):
-
     def test_parse_flow_campaign(self):
         ci_sheet = (
-            'type,sheet_name,new_name,group\n'
-            'create_campaign,my_campaign,renamed_campaign,My Group\n'
-            'create_flow,my_basic_flow,,\n'
+            "type,sheet_name,new_name,group\n"
+            "create_campaign,my_campaign,renamed_campaign,My Group\n"
+            "create_flow,my_basic_flow,,\n"
         )
         my_campaign = (
-            'offset,unit,event_type,delivery_hour,message,relative_to,start_mode,flow\n'
-            '15,H,F,,,Created On,I,my_basic_flow\n'
+            "offset,unit,event_type,delivery_hour,message,relative_to,start_mode,flow\n"
+            "15,H,F,,,Created On,I,my_basic_flow\n"
         )
         my_basic_flow = (
-            'row_id,type,from,message_text\n'
-            ',send_message,start,Some text\n'
+            "row_id,type,from,message_text\n" ",send_message,start,Some text\n"
         )
 
-        sheet_reader = MockSheetReader(ci_sheet, {'my_campaign' : my_campaign, 'my_basic_flow' : my_basic_flow})
+        sheet_reader = MockSheetReader(
+            ci_sheet, {"my_campaign": my_campaign, "my_basic_flow": my_basic_flow}
+        )
         ci_parser = ContentIndexParser(sheet_reader)
         container = ci_parser.parse_all()
         render_output = container.render()
@@ -487,40 +558,40 @@ class TestParseCampaigns(unittest.TestCase):
         self.assertEqual(render_output["campaigns"][0]["group"]["name"], "My Group")
         event = render_output["campaigns"][0]["events"][0]
         self.assertEqual(event["offset"], 15)
-        self.assertEqual(event["unit"], 'H')
-        self.assertEqual(event["event_type"], 'F')
+        self.assertEqual(event["unit"], "H")
+        self.assertEqual(event["event_type"], "F")
         self.assertEqual(event["delivery_hour"], -1)
         self.assertEqual(event["message"], None)
-        self.assertEqual(event["relative_to"], {'label' : 'Created On', 'key' : 'created_on'})
-        self.assertEqual(event["start_mode"], 'I')
-        self.assertEqual(event["flow"]["name"], 'my_basic_flow')
+        self.assertEqual(
+            event["relative_to"], {"label": "Created On", "key": "created_on"}
+        )
+        self.assertEqual(event["start_mode"], "I")
+        self.assertEqual(event["flow"]["name"], "my_basic_flow")
         self.assertEqual(event["flow"]["uuid"], render_output["flows"][0]["uuid"])
-        self.assertIsNone(event.get('base_language'))
+        self.assertIsNone(event.get("base_language"))
 
     def test_parse_message_campaign(self):
         ci_sheet = (
-            'type,sheet_name,new_name,group\n'
-            'create_campaign,my_campaign,,My Group\n'
+            "type,sheet_name,new_name,group\n" "create_campaign,my_campaign,,My Group\n"
         )
         my_campaign = (
-            'offset,unit,event_type,delivery_hour,message,relative_to,start_mode,flow\n'
-            '150,D,M,12,Messagetext,Created On,I,\n'
+            "offset,unit,event_type,delivery_hour,message,relative_to,start_mode,flow\n"
+            "150,D,M,12,Messagetext,Created On,I,\n"
         )
 
-        sheet_reader = MockSheetReader(ci_sheet, {'my_campaign' : my_campaign})
+        sheet_reader = MockSheetReader(ci_sheet, {"my_campaign": my_campaign})
         ci_parser = ContentIndexParser(sheet_reader)
         container = ci_parser.parse_all()
         render_output = container.render()
         self.assertEqual(render_output["campaigns"][0]["name"], "my_campaign")
         event = render_output["campaigns"][0]["events"][0]
-        self.assertEqual(event["event_type"], 'M')
+        self.assertEqual(event["event_type"], "M")
         self.assertEqual(event["delivery_hour"], 12)
-        self.assertEqual(event["message"], {'eng': 'Messagetext'})
-        self.assertEqual(event["base_language"], 'eng')
+        self.assertEqual(event["message"], {"eng": "Messagetext"})
+        self.assertEqual(event["base_language"], "eng")
 
 
 class TestParseFromFile(unittest.TestCase):
-
     def setUp(self):
         self.input_dir = TESTS_ROOT / "input/example1"
 
@@ -530,19 +601,30 @@ class TestParseFromFile(unittest.TestCase):
             if flow["name"] == flow_name:
                 flow_found = True
                 actions = traverse_flow(flow, context or Context())
-                actions_exp = list(zip(['send_msg']*len(messages_exp), messages_exp))
+                actions_exp = list(zip(["send_msg"] * len(messages_exp), messages_exp))
                 self.assertEqual(actions, actions_exp)
         if not flow_found:
-            self.assertTrue(False, msg=f'Flow with name "{flow_name}" does not exist in output.')
+            self.assertTrue(
+                False, msg=f'Flow with name "{flow_name}" does not exist in output.'
+            )
 
     def compare_to_expected(self, render_output):
-        self.compare_messages(render_output, 'my_basic_flow', ['Some text'])
-        self.compare_messages(render_output, 'my_template - row1', ['Value1', 'Happy1 and Sad1'])
-        self.compare_messages(render_output, 'my_template - row2', ['Value2', 'Happy2 and Sad2'])
+        self.compare_messages(render_output, "my_basic_flow", ["Some text"])
+        self.compare_messages(
+            render_output, "my_template - row1", ["Value1", "Happy1 and Sad1"]
+        )
+        self.compare_messages(
+            render_output, "my_template - row2", ["Value2", "Happy2 and Sad2"]
+        )
         self.assertEqual(render_output["campaigns"][0]["name"], "my_campaign")
         self.assertEqual(render_output["campaigns"][0]["group"]["name"], "My Group")
-        self.assertEqual(render_output["campaigns"][0]["events"][0]["flow"]["name"], 'my_basic_flow')
-        self.assertEqual(render_output["campaigns"][0]["events"][0]["flow"]["uuid"], render_output["flows"][2]["uuid"])
+        self.assertEqual(
+            render_output["campaigns"][0]["events"][0]["flow"]["name"], "my_basic_flow"
+        )
+        self.assertEqual(
+            render_output["campaigns"][0]["events"][0]["flow"]["uuid"],
+            render_output["flows"][2]["uuid"],
+        )
 
     def check_example1(self, ci_parser):
         container = ci_parser.parse_all()
@@ -552,19 +634,13 @@ class TestParseFromFile(unittest.TestCase):
     def test_example1_csv(self):
         # Same test as test_generate_flows but with csvs
         sheet_reader = CSVSheetReader(self.input_dir / "content_index.csv")
-        ci_parser = ContentIndexParser(
-            sheet_reader,
-            'tests.input.example1.nestedmodel'
-        )
+        ci_parser = ContentIndexParser(sheet_reader, "tests.input.example1.nestedmodel")
         self.check_example1(ci_parser)
 
     def test_example1_split_csv(self):
         # Same test as test_generate_flows but with csvs
         sheet_reader = CSVSheetReader(self.input_dir / "content_index1.csv")
-        ci_parser = ContentIndexParser(
-            sheet_reader,
-            'tests.input.example1.nestedmodel'
-        )
+        ci_parser = ContentIndexParser(sheet_reader, "tests.input.example1.nestedmodel")
         sheet_reader = CSVSheetReader(self.input_dir / "content_index2.csv")
         ci_parser.add_content_index(sheet_reader)
         self.check_example1(ci_parser)
@@ -572,8 +648,5 @@ class TestParseFromFile(unittest.TestCase):
     def test_example1_xlsx(self):
         # Same test as above
         sheet_reader = XLSXSheetReader(self.input_dir / "content_index.xlsx")
-        ci_parser = ContentIndexParser(
-            sheet_reader,
-            'tests.input.example1.nestedmodel'
-        )
+        ci_parser = ContentIndexParser(sheet_reader, "tests.input.example1.nestedmodel")
         self.check_example1(ci_parser)

--- a/tests/test_differentways.py
+++ b/tests/test_differentways.py
@@ -7,104 +7,119 @@ from tests.models import FromWrong
 
 
 output_instance = {
-    'row_id': '5',
-    'conditions': [
-        {'value':'1', 'var':'', 'type':'has_phrase', 'name':'A'},
-        {'value':'2', 'var':'', 'type':'has_phrase', 'name':'B'},
-        {'value':'3', 'var':'', 'type':'has_phrase', 'name':''},
-    ]
+    "row_id": "5",
+    "conditions": [
+        {"value": "1", "var": "", "type": "has_phrase", "name": "A"},
+        {"value": "2", "var": "", "type": "has_phrase", "name": "B"},
+        {"value": "3", "var": "", "type": "has_phrase", "name": ""},
+    ],
 }
 
 input1 = {
-    'row_id': '5',
-    'conditions.*.value' : ['1', '2', '3'],
-    'conditions.*.var' : '',
-    'conditions.*.type' : ['has_phrase', 'has_phrase', 'has_phrase'],
-    'conditions.*.name' : ['A','B',''],
+    "row_id": "5",
+    "conditions.*.value": ["1", "2", "3"],
+    "conditions.*.var": "",
+    "conditions.*.type": ["has_phrase", "has_phrase", "has_phrase"],
+    "conditions.*.name": ["A", "B", ""],
 }
 
 input2 = {
-    'row_id': '5',
-    'conditions.*.value' : ['1', '2', '3'],
-    'conditions.*.var' : '',
-    'conditions.*.type' : ['has_phrase', 'has_phrase', 'has_phrase'],
-    'conditions.*.name' : ['A','B'],
+    "row_id": "5",
+    "conditions.*.value": ["1", "2", "3"],
+    "conditions.*.var": "",
+    "conditions.*.type": ["has_phrase", "has_phrase", "has_phrase"],
+    "conditions.*.name": ["A", "B"],
 }
 
 input3 = {
-    'row_id': '5',
-    'conditions.*.value' : ['1', '2', '3'],
-    'conditions.*.var' : '',
-    'conditions.*.type' : 'has_phrase',
-    'conditions.*.name' : ['A','B',''],
+    "row_id": "5",
+    "conditions.*.value": ["1", "2", "3"],
+    "conditions.*.var": "",
+    "conditions.*.type": "has_phrase",
+    "conditions.*.name": ["A", "B", ""],
 }
 
 input4 = {
-    'row_id': '5',
-    'conditions.1' : ['1', '', 'has_phrase', 'A'],
-    'conditions.2' : ['2', '', 'has_phrase', 'B'],
-    'conditions.3' : ['3', '', 'has_phrase', ''],
+    "row_id": "5",
+    "conditions.1": ["1", "", "has_phrase", "A"],
+    "conditions.2": ["2", "", "has_phrase", "B"],
+    "conditions.3": ["3", "", "has_phrase", ""],
 }
 
 input5 = {
-    'row_id': '5',
-    'conditions.1' : ['1', '', 'has_phrase', 'A'],
-    'conditions.2' : ['2', '', 'has_phrase', 'B'],
-    'conditions.3' : ['3', '', 'has_phrase'],
+    "row_id": "5",
+    "conditions.1": ["1", "", "has_phrase", "A"],
+    "conditions.2": ["2", "", "has_phrase", "B"],
+    "conditions.3": ["3", "", "has_phrase"],
 }
 
 input6 = {
-    'row_id': '5',
-    'conditions.1' : [['value', '1'], ['type', 'has_phrase'], ['name', 'A']],
-    'conditions.2' : [['value', '2'], ['type', 'has_phrase'], ['name', 'B']],
-    'conditions.3' : [['value', '3'], ['type', 'has_phrase']],
+    "row_id": "5",
+    "conditions.1": [["value", "1"], ["type", "has_phrase"], ["name", "A"]],
+    "conditions.2": [["value", "2"], ["type", "has_phrase"], ["name", "B"]],
+    "conditions.3": [["value", "3"], ["type", "has_phrase"]],
 }
 
 input7 = {
-    'row_id': '5',
-    'conditions.1' : ['1', '', 'has_phrase', ['name', 'A']],
-    'conditions.2' : ['2', '', ['type', 'has_phrase'], ['name', 'B']],
-    'conditions.3' : ['3', ['type', 'has_phrase']],
+    "row_id": "5",
+    "conditions.1": ["1", "", "has_phrase", ["name", "A"]],
+    "conditions.2": ["2", "", ["type", "has_phrase"], ["name", "B"]],
+    "conditions.3": ["3", ["type", "has_phrase"]],
 }
 
 input8 = {
-    'row_id': '5',
-    'conditions' : [['1', '', 'has_phrase', 'A'], ['2', '', 'has_phrase', 'B'], ['3', '', 'has_phrase', '']],
+    "row_id": "5",
+    "conditions": [
+        ["1", "", "has_phrase", "A"],
+        ["2", "", "has_phrase", "B"],
+        ["3", "", "has_phrase", ""],
+    ],
 }
 
 input9 = {
-    'row_id': '5',
-    'conditions.1.value' : '1',
-    'conditions.1.type' : 'has_phrase',
-    'conditions.1.name' : 'A',
-    'conditions.2.value' : '2',
-    'conditions.2.type' : 'has_phrase',
-    'conditions.2.name' : 'B',
-    'conditions.3.value' : '3',
-    'conditions.3.type' : 'has_phrase',
+    "row_id": "5",
+    "conditions.1.value": "1",
+    "conditions.1.type": "has_phrase",
+    "conditions.1.name": "A",
+    "conditions.2.value": "2",
+    "conditions.2.type": "has_phrase",
+    "conditions.2.name": "B",
+    "conditions.3.value": "3",
+    "conditions.3.type": "has_phrase",
 }
 
 
 input_single_kwarg = {
-    'row_id': '5',
-    'conditions.1' : ['value', '3'],
+    "row_id": "5",
+    "conditions.1": ["value", "3"],
 }
 
-output_single_kwarg_exp = FromWrong(**{
-    'row_id': '5',
-    'conditions': [
-        {'value':'3', 'var':'', 'type':'', 'name':''},
-    ]
-})
+output_single_kwarg_exp = FromWrong(
+    **{
+        "row_id": "5",
+        "conditions": [
+            {"value": "3", "var": "", "type": "", "name": ""},
+        ],
+    }
+)
 
 
 class TestDifferentWays(unittest.TestCase):
-
     def setUp(self):
         self.parser = RowParser(FromWrong, MockCellParser())
 
     def test_different_ways(self):
-        inputs = [input1, input2, input3, input4, input5, input6, input7, input8, input9]
+        inputs = [
+            input1,
+            input2,
+            input3,
+            input4,
+            input5,
+            input6,
+            input7,
+            input8,
+            input9,
+        ]
         outputs = []
 
         for inp in inputs:
@@ -121,5 +136,5 @@ class TestDifferentWays(unittest.TestCase):
         self.assertEqual(output_single_kwarg, output_single_kwarg_exp)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_flowparser.py
+++ b/tests/test_flowparser.py
@@ -29,7 +29,6 @@ from tests.utils import (
 
 
 class TestParsing(unittest.TestCase):
-
     def setUp(self) -> None:
         self.row_parser = RowParser(FlowRowModel, CellParser())
 
@@ -40,73 +39,83 @@ class TestParsing(unittest.TestCase):
 
     def get_render_output(self, flow_name, input_rows):
         sheet_parser = MockSheetParser(None, input_rows)
-        parser = FlowParser(RapidProContainer(), flow_name=flow_name, sheet_parser=sheet_parser)
+        parser = FlowParser(
+            RapidProContainer(), flow_name=flow_name, sheet_parser=sheet_parser
+        )
         flow_container = parser.parse()
         return flow_container.render()
 
     def test_send_message(self):
-        render_output = self.get_render_output('send_message', [get_start_row()])
+        render_output = self.get_render_output("send_message", [get_start_row()])
 
-        node_0 = render_output['nodes'][0]
-        node_0_actions = node_0['actions']
+        node_0 = render_output["nodes"][0]
+        node_0_actions = node_0["actions"]
 
-        self.assertEqual(node_0_actions[0]['type'], 'send_msg')
-        self.assertEqual(node_0_actions[0]['text'], 'Text of message')
-        self.assertEqual(len(node_0_actions[0]['attachments']), 0)
-        self.assertEqual(node_0_actions[0]['quick_replies'], ['Answer 1', 'Answer 2'])
+        self.assertEqual(node_0_actions[0]["type"], "send_msg")
+        self.assertEqual(node_0_actions[0]["text"], "Text of message")
+        self.assertEqual(len(node_0_actions[0]["attachments"]), 0)
+        self.assertEqual(node_0_actions[0]["quick_replies"], ["Answer 1", "Answer 2"])
 
     def test_send_message_with_template(self):
         data_row1 = get_start_row()
         data_row2 = get_message_with_templating()
-        render_output = self.get_render_output('send_message_with_template', [data_row1, data_row2])
+        render_output = self.get_render_output(
+            "send_message_with_template", [data_row1, data_row2]
+        )
 
-        node_0 = render_output['nodes'][0]
-        node_0_action = node_0['actions'][0]
-        self.assertNotIn('templating', node_0_action)
+        node_0 = render_output["nodes"][0]
+        node_0_action = node_0["actions"][0]
+        self.assertNotIn("templating", node_0_action)
 
-        node_1 = render_output['nodes'][1]
-        node_1_action = node_1['actions'][0]
-        self.assertIn('templating', node_1_action)
-        self.assertIn('uuid', node_1_action['templating'])
-        self.assertEqual(node_1_action['templating']['template']['name'], 'template name')
-        self.assertEqual(node_1_action['templating']['template']['uuid'], 'template uuid')
-        self.assertEqual(node_1_action['templating']['variables'], ['var1', 'var2'])
+        node_1 = render_output["nodes"][1]
+        node_1_action = node_1["actions"][0]
+        self.assertIn("templating", node_1_action)
+        self.assertIn("uuid", node_1_action["templating"])
+        self.assertEqual(
+            node_1_action["templating"]["template"]["name"], "template name"
+        )
+        self.assertEqual(
+            node_1_action["templating"]["template"]["uuid"], "template uuid"
+        )
+        self.assertEqual(node_1_action["templating"]["variables"], ["var1", "var2"])
 
     def test_linear(self):
         data_row1 = get_start_row()
         data_row2 = get_unconditional_node_from_1()
-        data_row2.edges[0].from_ = ''  # implicit continue from last node
-        render_output = self.get_render_output('linear', [data_row1, data_row2])
+        data_row2.edges[0].from_ = ""  # implicit continue from last node
+        render_output = self.get_render_output("linear", [data_row1, data_row2])
 
-        node_0 = render_output['nodes'][0]
-        node_1 = render_output['nodes'][1]
-        node_1_actions = node_1['actions']
+        node_0 = render_output["nodes"][0]
+        node_1 = render_output["nodes"][1]
+        node_1_actions = node_1["actions"]
 
-        self.assertEqual(node_1_actions[0]['text'], 'Unconditional message')
-        self.assertEqual(len(node_0['exits']), 1)
-        self.assertIsNone(node_0.get('router'))
-        self.assertEqual(node_0['exits'][0]['destination_uuid'], node_1['uuid'])
-        self.assertEqual(node_1['exits'][0]['destination_uuid'], None)
+        self.assertEqual(node_1_actions[0]["text"], "Unconditional message")
+        self.assertEqual(len(node_0["exits"]), 1)
+        self.assertIsNone(node_0.get("router"))
+        self.assertEqual(node_0["exits"][0]["destination_uuid"], node_1["uuid"])
+        self.assertEqual(node_1["exits"][0]["destination_uuid"], None)
 
     def test_only_conditional(self):
         data_row1 = get_start_row()
         data_row3 = get_conditional_node_from_1()
-        render_output = self.get_render_output('only_conditional', [data_row1, data_row3])
+        render_output = self.get_render_output(
+            "only_conditional", [data_row1, data_row3]
+        )
 
-        self.assertEqual(len(render_output['nodes']), 3)
-        node_0 = render_output['nodes'][0]
-        node_1 = render_output['nodes'][1]
-        node_2 = render_output['nodes'][2]
-        node_2_actions = node_2['actions']
+        self.assertEqual(len(render_output["nodes"]), 3)
+        node_0 = render_output["nodes"][0]
+        node_1 = render_output["nodes"][1]
+        node_2 = render_output["nodes"][2]
+        node_2_actions = node_2["actions"]
 
-        self.assertEqual(node_2_actions[0]['text'], 'Message if @fields.name == 3')
-        self.assertEqual(len(node_1['exits']), 2)
-        self.assertIsNone(node_0.get('router'))
-        self.assertIsNotNone(node_1.get('router'))
-        self.assertEqual(node_0['exits'][0]['destination_uuid'], node_1['uuid'])
-        self.assertEqual(node_1['exits'][0]['destination_uuid'], node_2['uuid'])
-        self.assertEqual(node_1['exits'][1]['destination_uuid'], None)
-        self.assertEqual(node_2['exits'][0]['destination_uuid'], None)
+        self.assertEqual(node_2_actions[0]["text"], "Message if @fields.name == 3")
+        self.assertEqual(len(node_1["exits"]), 2)
+        self.assertIsNone(node_0.get("router"))
+        self.assertIsNotNone(node_1.get("router"))
+        self.assertEqual(node_0["exits"][0]["destination_uuid"], node_1["uuid"])
+        self.assertEqual(node_1["exits"][0]["destination_uuid"], node_2["uuid"])
+        self.assertEqual(node_1["exits"][1]["destination_uuid"], None)
+        self.assertEqual(node_2["exits"][0]["destination_uuid"], None)
 
     def test_split1(self):
         data_row1 = get_start_row()
@@ -123,154 +132,170 @@ class TestParsing(unittest.TestCase):
         self.check_split(data_rows)
 
     def check_split(self, data_rows):
-        render_output = self.get_render_output('split', data_rows)
+        render_output = self.get_render_output("split", data_rows)
 
-        node_start = render_output['nodes'][0]
-        node_switch = find_node_by_uuid(render_output, node_start['exits'][0]['destination_uuid'])
-        default_destination = find_destination_uuid(node_switch, Context(variables={'@fields.name':'5'}))
+        node_start = render_output["nodes"][0]
+        node_switch = find_node_by_uuid(
+            render_output, node_start["exits"][0]["destination_uuid"]
+        )
+        default_destination = find_destination_uuid(
+            node_switch, Context(variables={"@fields.name": "5"})
+        )
         node_2 = find_node_by_uuid(render_output, default_destination)
-        cond_destination = find_destination_uuid(node_switch, Context(variables={'@fields.name':'3'}))
+        cond_destination = find_destination_uuid(
+            node_switch, Context(variables={"@fields.name": "3"})
+        )
         node_3 = find_node_by_uuid(render_output, cond_destination)
-        node_2_actions = node_2['actions']
-        node_3_actions = node_3['actions']
+        node_2_actions = node_2["actions"]
+        node_3_actions = node_3["actions"]
 
-        self.assertEqual(node_3_actions[0]['text'], 'Message if @fields.name == 3')
-        self.assertEqual(node_2_actions[0]['text'], 'Unconditional message')
-        self.assertEqual(len(node_switch['exits']), 2)
-        self.assertIsNone(node_start.get('router'))
-        self.assertIsNotNone(node_switch.get('router'))
+        self.assertEqual(node_3_actions[0]["text"], "Message if @fields.name == 3")
+        self.assertEqual(node_2_actions[0]["text"], "Unconditional message")
+        self.assertEqual(len(node_switch["exits"]), 2)
+        self.assertIsNone(node_start.get("router"))
+        self.assertIsNotNone(node_switch.get("router"))
 
     def test_no_switch_node_rows(self):
-        render_output = self.get_render_output_from_file('no_switch_node', 'input/no_switch_nodes.csv')
+        render_output = self.get_render_output_from_file(
+            "no_switch_node", "input/no_switch_nodes.csv"
+        )
 
         # Check that node UUIDs are maintained
-        nodes = render_output['nodes']
-        actual_node_uuids = [node['uuid'] for node in nodes]
-        expected_node_uuids = [row.node_uuid for row in self.rows][3:-1]  # The first 4 and last 2 rows are actions joined into a single node.
+        nodes = render_output["nodes"]
+        actual_node_uuids = [node["uuid"] for node in nodes]
+        expected_node_uuids = [row.node_uuid for row in self.rows][
+            3:-1
+        ]  # The first 4 and last 2 rows are actions joined into a single node.
         self.assertEqual(expected_node_uuids, actual_node_uuids)
 
-        self.assertEqual(render_output['name'], 'no_switch_node')
-        self.assertEqual(render_output['type'], 'messaging')
-        self.assertEqual(render_output['language'], 'eng')
+        self.assertEqual(render_output["name"], "no_switch_node")
+        self.assertEqual(render_output["type"], "messaging")
+        self.assertEqual(render_output["language"], "eng")
 
-        self.assertEqual(len(render_output['nodes']), 6)
+        self.assertEqual(len(render_output["nodes"]), 6)
 
-        node_0 = render_output['nodes'][0]
-        node_0_actions = node_0['actions']
+        node_0 = render_output["nodes"][0]
+        node_0_actions = node_0["actions"]
 
         self.assertEqual(len(node_0_actions), 4)
 
-        self.assertEqual(node_0_actions[0]['type'], 'send_msg')
-        self.assertEqual(node_0_actions[0]['text'], 'this is a send message node')
-        self.assertEqual(len(node_0_actions[0]['attachments']), 0)
-        self.assertIn('qr1', node_0_actions[0]['quick_replies'])
-        self.assertIn('qr2', node_0_actions[0]['quick_replies'])
+        self.assertEqual(node_0_actions[0]["type"], "send_msg")
+        self.assertEqual(node_0_actions[0]["text"], "this is a send message node")
+        self.assertEqual(len(node_0_actions[0]["attachments"]), 0)
+        self.assertIn("qr1", node_0_actions[0]["quick_replies"])
+        self.assertIn("qr2", node_0_actions[0]["quick_replies"])
 
-        self.assertEqual(node_0_actions[1]['type'], 'send_msg')
-        self.assertEqual(node_0_actions[1]['text'], 'message with image')
-        self.assertEqual(len(node_0_actions[1]['attachments']), 1)
-        self.assertEqual(node_0_actions[1]['attachments'][0], 'image:image u')
-        self.assertEqual(len(node_0_actions[1]['quick_replies']), 0)
+        self.assertEqual(node_0_actions[1]["type"], "send_msg")
+        self.assertEqual(node_0_actions[1]["text"], "message with image")
+        self.assertEqual(len(node_0_actions[1]["attachments"]), 1)
+        self.assertEqual(node_0_actions[1]["attachments"][0], "image:image u")
+        self.assertEqual(len(node_0_actions[1]["quick_replies"]), 0)
 
-        self.assertEqual(node_0_actions[2]['type'], 'send_msg')
-        self.assertEqual(node_0_actions[2]['text'], 'message with audio')
-        self.assertEqual(len(node_0_actions[2]['attachments']), 1)
-        self.assertEqual(node_0_actions[2]['attachments'][0], 'audio:audio u')
-        self.assertEqual(len(node_0_actions[2]['quick_replies']), 0)
+        self.assertEqual(node_0_actions[2]["type"], "send_msg")
+        self.assertEqual(node_0_actions[2]["text"], "message with audio")
+        self.assertEqual(len(node_0_actions[2]["attachments"]), 1)
+        self.assertEqual(node_0_actions[2]["attachments"][0], "audio:audio u")
+        self.assertEqual(len(node_0_actions[2]["quick_replies"]), 0)
 
-        self.assertEqual(node_0_actions[3]['type'], 'send_msg')
-        self.assertEqual(node_0_actions[3]['text'], 'message with video')
-        self.assertEqual(len(node_0_actions[3]['attachments']), 1)
-        self.assertEqual(node_0_actions[3]['attachments'][0], 'video:video u')
-        self.assertEqual(len(node_0_actions[3]['quick_replies']), 0)
+        self.assertEqual(node_0_actions[3]["type"], "send_msg")
+        self.assertEqual(node_0_actions[3]["text"], "message with video")
+        self.assertEqual(len(node_0_actions[3]["attachments"]), 1)
+        self.assertEqual(node_0_actions[3]["attachments"][0], "video:video u")
+        self.assertEqual(len(node_0_actions[3]["quick_replies"]), 0)
 
-        node_1 = render_output['nodes'][1]
-        node_1_actions = node_1['actions']
+        node_1 = render_output["nodes"][1]
+        node_1_actions = node_1["actions"]
 
-        self.assertEqual(node_0['exits'][0]['destination_uuid'], node_1['uuid'])
+        self.assertEqual(node_0["exits"][0]["destination_uuid"], node_1["uuid"])
 
         self.assertEqual(len(node_1_actions), 1)
-        self.assertEqual(node_1_actions[0]['type'], 'set_contact_field')
-        self.assertEqual(node_1_actions[0]['field']['key'], 'test_variable')
-        self.assertEqual(node_1_actions[0]['field']['name'], 'test variable')
-        self.assertEqual(node_1_actions[0]['value'], 'test value ')
+        self.assertEqual(node_1_actions[0]["type"], "set_contact_field")
+        self.assertEqual(node_1_actions[0]["field"]["key"], "test_variable")
+        self.assertEqual(node_1_actions[0]["field"]["name"], "test variable")
+        self.assertEqual(node_1_actions[0]["value"], "test value ")
 
-        node_2 = render_output['nodes'][2]
-        node_2_actions = render_output['nodes'][2]['actions']
+        node_2 = render_output["nodes"][2]
+        node_2_actions = render_output["nodes"][2]["actions"]
 
-        self.assertEqual(node_1['exits'][0]['destination_uuid'], node_2['uuid'])
+        self.assertEqual(node_1["exits"][0]["destination_uuid"], node_2["uuid"])
 
         self.assertEqual(len(node_2_actions), 1)
-        self.assertEqual(node_2_actions[0]['type'], 'add_contact_groups')
-        self.assertEqual(len(node_2_actions[0]['groups']), 1)
-        self.assertEqual(node_2_actions[0]['groups'][0]['name'], 'test group')
+        self.assertEqual(node_2_actions[0]["type"], "add_contact_groups")
+        self.assertEqual(len(node_2_actions[0]["groups"]), 1)
+        self.assertEqual(node_2_actions[0]["groups"][0]["name"], "test group")
 
-        node_3 = render_output['nodes'][3]
-        node_3_actions = render_output['nodes'][3]['actions']
+        node_3 = render_output["nodes"][3]
+        node_3_actions = render_output["nodes"][3]["actions"]
 
-        self.assertEqual(node_2['exits'][0]['destination_uuid'], node_3['uuid'])
+        self.assertEqual(node_2["exits"][0]["destination_uuid"], node_3["uuid"])
         self.assertEqual(len(node_3_actions), 1)
-        self.assertEqual('remove_contact_groups', node_3_actions[0]['type'])
-        self.assertEqual(len(node_3_actions[0]['groups']), 1)
-        self.assertEqual('test group', node_3_actions[0]['groups'][0]['name'])
+        self.assertEqual("remove_contact_groups", node_3_actions[0]["type"])
+        self.assertEqual(len(node_3_actions[0]["groups"]), 1)
+        self.assertEqual("test group", node_3_actions[0]["groups"][0]["name"])
 
         # Make sure it's the same group
-        self.assertEqual(node_2_actions[0]['groups'][0]['uuid'], node_3_actions[0]['groups'][0]['uuid'])
+        self.assertEqual(
+            node_2_actions[0]["groups"][0]["uuid"],
+            node_3_actions[0]["groups"][0]["uuid"],
+        )
 
-        node_4 = render_output['nodes'][4]
-        node_4_actions = render_output['nodes'][4]['actions']
+        node_4 = render_output["nodes"][4]
+        node_4_actions = render_output["nodes"][4]["actions"]
 
-        self.assertEqual(node_3['exits'][0]['destination_uuid'], node_4['uuid'])
+        self.assertEqual(node_3["exits"][0]["destination_uuid"], node_4["uuid"])
         self.assertEqual(len(node_4_actions), 1)
-        self.assertEqual('set_run_result', node_4_actions[0]['type'])
-        self.assertEqual('result name', node_4_actions[0]['name'])
-        self.assertEqual('result value', node_4_actions[0]['value'])
-        self.assertEqual('my_result_cat', node_4_actions[0]['category'])
+        self.assertEqual("set_run_result", node_4_actions[0]["type"])
+        self.assertEqual("result name", node_4_actions[0]["name"])
+        self.assertEqual("result value", node_4_actions[0]["value"])
+        self.assertEqual("my_result_cat", node_4_actions[0]["category"])
 
-        node_5 = render_output['nodes'][5]
-        self.assertEqual(node_4['exits'][0]['destination_uuid'], node_5['uuid'])
-        self.assertIsNone(node_5['exits'][0]['destination_uuid'])
-        node_5_actions = node_5['actions']
+        node_5 = render_output["nodes"][5]
+        self.assertEqual(node_4["exits"][0]["destination_uuid"], node_5["uuid"])
+        self.assertIsNone(node_5["exits"][0]["destination_uuid"])
+        node_5_actions = node_5["actions"]
         self.assertEqual(len(node_5_actions), 2)
-        self.assertEqual(node_5_actions[0]['type'], 'set_contact_language')
-        self.assertEqual(node_5_actions[0]['language'], 'eng')
-        self.assertEqual(node_5_actions[1]['type'], 'set_contact_name')
-        self.assertEqual(node_5_actions[1]['name'], 'John Doe')
-
+        self.assertEqual(node_5_actions[0]["type"], "set_contact_language")
+        self.assertEqual(node_5_actions[0]["language"], "eng")
+        self.assertEqual(node_5_actions[1]["type"], "set_contact_name")
+        self.assertEqual(node_5_actions[1]["name"], "John Doe")
 
         # Check UI positions/types of the first two nodes
-        render_ui = render_output['_ui']['nodes']
-        self.assertIn(node_0['uuid'], render_ui)
-        pos0 = render_ui[node_0['uuid']]['position']
-        self.assertEqual((280, 73), (pos0['left'], pos0['top']))
-        self.assertEqual('execute_actions', render_ui[node_0['uuid']]['type'])
-        self.assertIn(node_1['uuid'], render_ui)
-        pos1 = render_ui[node_1['uuid']]['position']
-        self.assertEqual((280, 600), (pos1['left'], pos1['top']))
-        self.assertEqual('execute_actions', render_ui[node_1['uuid']]['type'])
+        render_ui = render_output["_ui"]["nodes"]
+        self.assertIn(node_0["uuid"], render_ui)
+        pos0 = render_ui[node_0["uuid"]]["position"]
+        self.assertEqual((280, 73), (pos0["left"], pos0["top"]))
+        self.assertEqual("execute_actions", render_ui[node_0["uuid"]]["type"])
+        self.assertIn(node_1["uuid"], render_ui)
+        pos1 = render_ui[node_1["uuid"]]["position"]
+        self.assertEqual((280, 600), (pos1["left"], pos1["top"]))
+        self.assertEqual("execute_actions", render_ui[node_1["uuid"]]["type"])
 
     def test_switch_node_rows(self):
-        render_output = self.get_render_output_from_file('switch_node', 'input/switch_nodes.csv')
+        render_output = self.get_render_output_from_file(
+            "switch_node", "input/switch_nodes.csv"
+        )
 
         # Check that node UUIDs are maintained
-        nodes = render_output['nodes']
-        actual_node_uuids = [node['uuid'] for node in nodes]
+        nodes = render_output["nodes"]
+        actual_node_uuids = [node["uuid"] for node in nodes]
         expected_node_uuids = [row.node_uuid for row in self.rows]
         self.assertEqual(expected_node_uuids, actual_node_uuids)
 
         # Check that No Response category is created even if not connected
         last_wait_node = nodes[-2]
-        self.assertEqual('No Response', last_wait_node['router']['categories'][-1]['name'])
+        self.assertEqual(
+            "No Response", last_wait_node["router"]["categories"][-1]["name"]
+        )
 
         # TODO: Ideally, there should be more explicit tests here.
         # At least the functionality is covered by the integration tests simulating the flow.
         # print(json.dumps(render_output, indent=2))
 
-        render_ui = render_output['_ui']['nodes']
-        f_uuid = lambda i: render_output['nodes'][i]['uuid']
-        f_uipos_dict = lambda i: render_ui[f_uuid(i)]['position']
-        f_uipos = lambda i: (f_uipos_dict(i)['left'], f_uipos_dict(i)['top'])
-        f_uitype = lambda i: render_ui[f_uuid(i)]['type']
+        render_ui = render_output["_ui"]["nodes"]
+        f_uuid = lambda i: render_output["nodes"][i]["uuid"]
+        f_uipos_dict = lambda i: render_ui[f_uuid(i)]["position"]
+        f_uipos = lambda i: (f_uipos_dict(i)["left"], f_uipos_dict(i)["top"])
+        f_uitype = lambda i: render_ui[f_uuid(i)]["type"]
         self.assertIn(f_uuid(0), render_ui)
         self.assertEqual((340, 0), f_uipos(0))
         self.assertEqual((360, 180), f_uipos(1))
@@ -289,589 +314,696 @@ class TestParsing(unittest.TestCase):
         self.assertEqual("wait_for_response", f_uitype(-2))
 
         # Ensure that wait_for_response cases are working as intended
-        node6 = render_output['nodes'][6]
+        node6 = render_output["nodes"][6]
         categories = node6["router"]["categories"]
         self.assertEqual(len(categories), 3)
-        self.assertEqual(categories[0]["name"], 'A')
-        self.assertEqual(categories[1]["name"], 'Other')
-        self.assertEqual(categories[2]["name"], 'No Response')
+        self.assertEqual(categories[0]["name"], "A")
+        self.assertEqual(categories[1]["name"], "Other")
+        self.assertEqual(categories[2]["name"], "No Response")
         self.assertEqual(len(node6["router"]["cases"]), 1)
 
     def test_groups_and_flows(self):
         # We check that references flows and group are assigned uuids consistently
-        tiny_uuid = '00000000-acec-434f-bc7c-14c584fc4bc8'
-        test_uuid = '8224bfe2-acec-434f-bc7c-14c584fc4bc8'
-        other_uuid = '12345678-acec-434f-bc7c-14c584fc4bc8'
-        test_group_dict = {'name': 'test group', 'uuid' : test_uuid}
-        other_group_dict = {'name': 'other group', 'uuid' : other_uuid}
-        tiny_flow_dict = {'name': 'tiny_flow', 'uuid' : tiny_uuid}
+        tiny_uuid = "00000000-acec-434f-bc7c-14c584fc4bc8"
+        test_uuid = "8224bfe2-acec-434f-bc7c-14c584fc4bc8"
+        other_uuid = "12345678-acec-434f-bc7c-14c584fc4bc8"
+        test_group_dict = {"name": "test group", "uuid": test_uuid}
+        other_group_dict = {"name": "other group", "uuid": other_uuid}
+        tiny_flow_dict = {"name": "tiny_flow", "uuid": tiny_uuid}
 
         # Make a flow with a single group node (no UUIDs), and put it into new container
         node = BasicNode()
-        node.add_action(AddContactGroupAction([Group('test group'), Group('other group')]))
-        tiny_flow = FlowContainer('tiny_flow', uuid=tiny_uuid)
+        node.add_action(
+            AddContactGroupAction([Group("test group"), Group("other group")])
+        )
+        tiny_flow = FlowContainer("tiny_flow", uuid=tiny_uuid)
         tiny_flow.add_node(node)
-        container = RapidProContainer(groups=[Group('other group', other_uuid)])
+        container = RapidProContainer(groups=[Group("other group", other_uuid)])
         container.add_flow(tiny_flow)
 
         # Add flow from sheet into container
-        dict_rows = get_dict_from_csv('input/groups_and_flows.csv')
+        dict_rows = get_dict_from_csv("input/groups_and_flows.csv")
         rows = [self.row_parser.parse_row(row) for row in dict_rows]
         sheet_parser = MockSheetParser(None, rows)
-        parser = FlowParser(container, flow_name='groups_and_flows', sheet_parser=sheet_parser)
+        parser = FlowParser(
+            container, flow_name="groups_and_flows", sheet_parser=sheet_parser
+        )
         parser.parse()
         # Render also invokes filling in all the flow/group UUIDs
         render_output = container.render()
 
         # Ensure container groups are complete and have correct UUIDs
-        self.assertIn(test_group_dict, render_output['groups'])
-        self.assertIn(other_group_dict, render_output['groups'])
+        self.assertIn(test_group_dict, render_output["groups"])
+        self.assertIn(other_group_dict, render_output["groups"])
         # These UUIDs are inferred from the sheet/the container groups, respectively
-        self.assertEqual(render_output['flows'][0]['nodes'][0]['actions'][0]['groups'], [test_group_dict, other_group_dict])
+        self.assertEqual(
+            render_output["flows"][0]["nodes"][0]["actions"][0]["groups"],
+            [test_group_dict, other_group_dict],
+        )
 
-        nodes = render_output['flows'][1]['nodes']
+        nodes = render_output["flows"][1]["nodes"]
         # This UUID appears only in a later occurrence of the group in the sheet
-        self.assertEqual(nodes[0]['actions'][0]['groups'], [test_group_dict])
+        self.assertEqual(nodes[0]["actions"][0]["groups"], [test_group_dict])
         # This UUID is missing from the sheet, but explicit in the flow definition
-        self.assertEqual(nodes[1]['actions'][0]['flow'], tiny_flow_dict)
+        self.assertEqual(nodes[1]["actions"][0]["flow"], tiny_flow_dict)
         # This UUID is explicit in the sheet
-        self.assertEqual(nodes[2]['actions'][0]['groups'], [test_group_dict])
+        self.assertEqual(nodes[2]["actions"][0]["groups"], [test_group_dict])
         # This UUID appears in a previous occurrence of the group in the sheet
-        self.assertEqual(nodes[3]['router']['cases'][0]['arguments'], [test_uuid, 'test group'])
+        self.assertEqual(
+            nodes[3]["router"]["cases"][0]["arguments"], [test_uuid, "test group"]
+        )
         # This UUID was part of the groups in the container, but not in the sheet
-        self.assertEqual(nodes[6]['actions'][0]['groups'], [other_group_dict])
+        self.assertEqual(nodes[6]["actions"][0]["groups"], [other_group_dict])
 
-        tiny_flow.uuid = 'something else'
+        tiny_flow.uuid = "something else"
         with self.assertRaises(ValueError):
             # The enter_flow node has a different uuid than the flow
             container.validate()
 
         tiny_flow.uuid = tiny_uuid
-        container.flows[1].nodes[2].actions[0].groups[0].uuid = 'something else'
+        container.flows[1].nodes[2].actions[0].groups[0].uuid = "something else"
         with self.assertRaises(ValueError):
             # The group is referenced by 2 different UUIDs
             container.validate()
 
 
 class TestBlocks(unittest.TestCase):
-
     def setUp(self) -> None:
         self.row_parser = RowParser(FlowRowModel, CellParser())
 
     def render_output_from_table_data(self, table_data, template_context=None):
-        table = tablib.import_set(table_data, format='csv')
-        parser = FlowParser(RapidProContainer(), 'basic loop', table, context=template_context or {})
+        table = tablib.import_set(table_data, format="csv")
+        parser = FlowParser(
+            RapidProContainer(), "basic loop", table, context=template_context or {}
+        )
         return parser.parse().render()
 
-    def run_example(self, table_data, messages_exp, context=None, template_context=None):
-        render_output = self.render_output_from_table_data(table_data, template_context or {})
+    def run_example(
+        self, table_data, messages_exp, context=None, template_context=None
+    ):
+        render_output = self.render_output_from_table_data(
+            table_data, template_context or {}
+        )
         actions = traverse_flow(render_output, context or Context())
-        actions_exp = list(zip(['send_msg']*len(messages_exp), messages_exp))
+        actions_exp = list(zip(["send_msg"] * len(messages_exp), messages_exp))
         self.assertEqual(actions, actions_exp)
 
-    def run_example_with_actions(self, table_data, actions_exp, context=None, template_context=None):
-        render_output = self.render_output_from_table_data(table_data, template_context or {})
+    def run_example_with_actions(
+        self, table_data, actions_exp, context=None, template_context=None
+    ):
+        render_output = self.render_output_from_table_data(
+            table_data, template_context or {}
+        )
         actions = traverse_flow(render_output, context or Context())
         self.assertEqual(actions, actions_exp)
 
 
 class TestLoops(TestBlocks):
-
     def test_basic_loop(self):
         table_data = (
-            'row_id,type,from,loop_variable,message_text\n'
-            '1,begin_for,start,i,1;2;3\n'
-            ',send_message,,,{{i}}. Some text\n'
-            ',end_for,,,\n'
+            "row_id,type,from,loop_variable,message_text\n"
+            "1,begin_for,start,i,1;2;3\n"
+            ",send_message,,,{{i}}. Some text\n"
+            ",end_for,,,\n"
         )
         render_output = self.render_output_from_table_data(table_data)
         nodes = render_output["nodes"]
         self.assertEqual(len(nodes), 3)
-        self.assertEqual(nodes[0]["actions"][0]["type"], 'send_msg')
-        self.assertEqual(nodes[0]["actions"][0]["text"], '1. Some text')
-        self.assertEqual(nodes[1]["actions"][0]["text"], '2. Some text')
-        self.assertEqual(nodes[2]["actions"][0]["text"], '3. Some text')
+        self.assertEqual(nodes[0]["actions"][0]["type"], "send_msg")
+        self.assertEqual(nodes[0]["actions"][0]["text"], "1. Some text")
+        self.assertEqual(nodes[1]["actions"][0]["text"], "2. Some text")
+        self.assertEqual(nodes[2]["actions"][0]["text"], "3. Some text")
         # Also check that the connectivity is correct
-        messages_exp = ['1. Some text','2. Some text','3. Some text']
+        messages_exp = ["1. Some text", "2. Some text", "3. Some text"]
         self.run_example(table_data, messages_exp)
 
     def test_enumerate(self):
         table_data = (
-            'row_id,type,from,loop_variable,message_text\n'
-            '1,begin_for,start,text;i,A;B;C\n'
-            ',send_message,,,{{i+1}}. {{text}}\n'
-            ',end_for,,,\n'
+            "row_id,type,from,loop_variable,message_text\n"
+            "1,begin_for,start,text;i,A;B;C\n"
+            ",send_message,,,{{i+1}}. {{text}}\n"
+            ",end_for,,,\n"
         )
         render_output = self.render_output_from_table_data(table_data)
         nodes = render_output["nodes"]
         self.assertEqual(len(nodes), 3)
-        self.assertEqual(nodes[0]["actions"][0]["type"], 'send_msg')
-        self.assertEqual(nodes[0]["actions"][0]["text"], '1. A')
-        self.assertEqual(nodes[1]["actions"][0]["text"], '2. B')
-        self.assertEqual(nodes[2]["actions"][0]["text"], '3. C')
+        self.assertEqual(nodes[0]["actions"][0]["type"], "send_msg")
+        self.assertEqual(nodes[0]["actions"][0]["text"], "1. A")
+        self.assertEqual(nodes[1]["actions"][0]["text"], "2. B")
+        self.assertEqual(nodes[2]["actions"][0]["text"], "3. C")
 
     def test_one_element_loop(self):
         table_data = (
-            'row_id,type,from,loop_variable,message_text\n'
-            '1,begin_for,start,i,label\n'
-            ',send_message,,,{{i}}. Some text\n'
-            ',end_for,,,\n'
+            "row_id,type,from,loop_variable,message_text\n"
+            "1,begin_for,start,i,label\n"
+            ",send_message,,,{{i}}. Some text\n"
+            ",end_for,,,\n"
         )
         render_output = self.render_output_from_table_data(table_data)
         nodes = render_output["nodes"]
         self.assertEqual(len(nodes), 1)
-        self.assertEqual(nodes[0]["actions"][0]["type"], 'send_msg')
-        self.assertEqual(nodes[0]["actions"][0]["text"], 'label. Some text')
+        self.assertEqual(nodes[0]["actions"][0]["type"], "send_msg")
+        self.assertEqual(nodes[0]["actions"][0]["text"], "label. Some text")
 
     def test_nested_loop(self):
         table_data = (
-            'row_id,type,from,loop_variable,message_text\n'
-            '1,begin_for,start,i,1;2\n'
-            ',begin_for,,j,A;B\n'
-            ',send_message,,,{{i}}{{j}}. Some text\n'
-            ',end_for,,,\n'
-            ',end_for,,,\n'
+            "row_id,type,from,loop_variable,message_text\n"
+            "1,begin_for,start,i,1;2\n"
+            ",begin_for,,j,A;B\n"
+            ",send_message,,,{{i}}{{j}}. Some text\n"
+            ",end_for,,,\n"
+            ",end_for,,,\n"
         )
-        messages_exp = ['1A. Some text','1B. Some text','2A. Some text','2B. Some text']
+        messages_exp = [
+            "1A. Some text",
+            "1B. Some text",
+            "2A. Some text",
+            "2B. Some text",
+        ]
         self.run_example(table_data, messages_exp)
 
     def test_loop_within_other_nodes(self):
         table_data = (
-            'row_id,type,from,loop_variable,message_text\n'
-            '1,send_message,start,,Starting text\n'
-            '2,begin_for,1,i,1;2\n'
-            ',send_message,,,{{i}}. Some text\n'
-            ',end_for,,,\n'
-            ',send_message,,,Following text\n'
+            "row_id,type,from,loop_variable,message_text\n"
+            "1,send_message,start,,Starting text\n"
+            "2,begin_for,1,i,1;2\n"
+            ",send_message,,,{{i}}. Some text\n"
+            ",end_for,,,\n"
+            ",send_message,,,Following text\n"
         )
-        messages_exp = ['Starting text','1. Some text','2. Some text','Following text']
+        messages_exp = [
+            "Starting text",
+            "1. Some text",
+            "2. Some text",
+            "Following text",
+        ]
         self.run_example(table_data, messages_exp)
 
     def test_nested_loop_with_other_nodes(self):
         table_data = (
-            'row_id,type,from,loop_variable,message_text\n'
-            '1,begin_for,start,i,1;2\n'
-            ',begin_for,,j,A;B\n'
-            ',send_message,,,{{i}}{{j}}. Some text\n'
-            ',end_for,,,\n'
-            ',send_message,,,End of inner loop\n'
-            ',end_for,,,\n'
-            ',send_message,,,End of outer loop\n'
+            "row_id,type,from,loop_variable,message_text\n"
+            "1,begin_for,start,i,1;2\n"
+            ",begin_for,,j,A;B\n"
+            ",send_message,,,{{i}}{{j}}. Some text\n"
+            ",end_for,,,\n"
+            ",send_message,,,End of inner loop\n"
+            ",end_for,,,\n"
+            ",send_message,,,End of outer loop\n"
         )
-        messages_exp = ['1A. Some text','1B. Some text','End of inner loop',
-                        '2A. Some text','2B. Some text','End of inner loop','End of outer loop']
+        messages_exp = [
+            "1A. Some text",
+            "1B. Some text",
+            "End of inner loop",
+            "2A. Some text",
+            "2B. Some text",
+            "End of inner loop",
+            "End of outer loop",
+        ]
         self.run_example(table_data, messages_exp)
 
     def test_loop_with_explicit_following_node(self):
         table_data = (
-            'row_id,type,from,loop_variable,message_text\n'
-            '2,begin_for,,i,1;2\n'
-            ',send_message,,,{{i}}. Some text\n'
-            ',end_for,,,\n'
-            ',send_message,2,,Following text\n'
+            "row_id,type,from,loop_variable,message_text\n"
+            "2,begin_for,,i,1;2\n"
+            ",send_message,,,{{i}}. Some text\n"
+            ",end_for,,,\n"
+            ",send_message,2,,Following text\n"
         )
-        messages_exp = ['1. Some text','2. Some text','Following text']
+        messages_exp = ["1. Some text", "2. Some text", "Following text"]
         self.run_example(table_data, messages_exp)
 
     def test_loop_with_goto(self):
         table_data = (
-            'row_id,type,from,condition,loop_variable,message_text\n'
-            '2,begin_for,start,,i,1;2\n'
-            ',send_message,,,,{{i}}. Some text\n'
-            ',end_for,,,,\n'
-            '3,wait_for_response,2,,,\n'
-            ',go_to,3,hello,,2\n'
-            ',send_message,3,,,Following text\n'
+            "row_id,type,from,condition,loop_variable,message_text\n"
+            "2,begin_for,start,,i,1;2\n"
+            ",send_message,,,,{{i}}. Some text\n"
+            ",end_for,,,,\n"
+            "3,wait_for_response,2,,,\n"
+            ",go_to,3,hello,,2\n"
+            ",send_message,3,,,Following text\n"
         )
-        messages_exp = ['1. Some text','2. Some text','Following text']
-        self.run_example(table_data, messages_exp, Context(inputs=['goodbye']))
-        messages_exp = ['1. Some text','2. Some text','1. Some text','2. Some text','Following text']
-        self.run_example(table_data, messages_exp, Context(inputs=['hello', 'goodbye']))
+        messages_exp = ["1. Some text", "2. Some text", "Following text"]
+        self.run_example(table_data, messages_exp, Context(inputs=["goodbye"]))
+        messages_exp = [
+            "1. Some text",
+            "2. Some text",
+            "1. Some text",
+            "2. Some text",
+            "Following text",
+        ]
+        self.run_example(table_data, messages_exp, Context(inputs=["hello", "goodbye"]))
 
     def test_loop_with_goto_into_middle_of_loop(self):
         table_data = (
-            'row_id,type,from,condition,loop_variable,message_text\n'
-            '2,begin_for,start,,i,1;2\n'
-            'item{{i}},send_message,,,,{{i}}. Some text\n'
-            ',end_for,,,,\n'
-            '3,wait_for_response,2,,,\n'
-            ',go_to,3,hello,,item2\n'
-            ',send_message,3,,,Following text\n'
+            "row_id,type,from,condition,loop_variable,message_text\n"
+            "2,begin_for,start,,i,1;2\n"
+            "item{{i}},send_message,,,,{{i}}. Some text\n"
+            ",end_for,,,,\n"
+            "3,wait_for_response,2,,,\n"
+            ",go_to,3,hello,,item2\n"
+            ",send_message,3,,,Following text\n"
         )
-        messages_exp = ['1. Some text','2. Some text','Following text']
-        self.run_example(table_data, messages_exp, Context(inputs=['goodbye']))
-        messages_exp = ['1. Some text','2. Some text','2. Some text','Following text']
-        self.run_example(table_data, messages_exp, Context(inputs=['hello', 'goodbye']))
+        messages_exp = ["1. Some text", "2. Some text", "Following text"]
+        self.run_example(table_data, messages_exp, Context(inputs=["goodbye"]))
+        messages_exp = [
+            "1. Some text",
+            "2. Some text",
+            "2. Some text",
+            "Following text",
+        ]
+        self.run_example(table_data, messages_exp, Context(inputs=["hello", "goodbye"]))
 
     def test_loop_over_object(self):
         class TestObj:
             def __init__(self, value):
                 self.value = value
-        test_objs = [TestObj('1'), TestObj('2'), TestObj('A')]
+
+        test_objs = [TestObj("1"), TestObj("2"), TestObj("A")]
         table_data = (
-            'row_id,type,from,loop_variable,message_text\n'
-            '2,begin_for,start,obj,{@test_objs@}\n'
-            ',send_message,,,Value: {{obj.value}}\n'
-            ',end_for,,,\n'
+            "row_id,type,from,loop_variable,message_text\n"
+            "2,begin_for,start,obj,{@test_objs@}\n"
+            ",send_message,,,Value: {{obj.value}}\n"
+            ",end_for,,,\n"
         )
-        messages_exp = ['Value: 1', 'Value: 2', 'Value: A']
-        self.run_example(table_data, messages_exp, template_context={'test_objs' : test_objs})
+        messages_exp = ["Value: 1", "Value: 2", "Value: A"]
+        self.run_example(
+            table_data, messages_exp, template_context={"test_objs": test_objs}
+        )
 
     def test_loop_over_range(self):
         table_data = (
-            'row_id,type,from,loop_variable,message_text\n'
-            '2,begin_for,,i,{@range(5)@}\n'
-            ',send_message,,,{{i}}. Some text\n'
-            ',end_for,,,\n'
+            "row_id,type,from,loop_variable,message_text\n"
+            "2,begin_for,,i,{@range(5)@}\n"
+            ",send_message,,,{{i}}. Some text\n"
+            ",end_for,,,\n"
         )
-        messages_exp = [f'{i}. Some text' for i in range(5)]
+        messages_exp = [f"{i}. Some text" for i in range(5)]
         self.run_example(table_data, messages_exp)
 
 
 class TestConditionals(TestBlocks):
-
     def test_block_within_other_nodes(self):
         table_data = (
-            'row_id,type,from,message_text\n'
-            ',send_message,start,Starting text\n'
-            ',begin_block,,\n'
-            ',send_message,,Some text\n'
-            ',end_block,,\n'
-            ',send_message,,Following text\n'
+            "row_id,type,from,message_text\n"
+            ",send_message,start,Starting text\n"
+            ",begin_block,,\n"
+            ",send_message,,Some text\n"
+            ",end_block,,\n"
+            ",send_message,,Following text\n"
         )
-        messages_exp = ['Starting text','Some text','Following text']
+        messages_exp = ["Starting text", "Some text", "Following text"]
         self.run_example(table_data, messages_exp)
 
     def test_block_with_explicit_from(self):
         table_data = (
-            'row_id,type,from,message_text\n'
-            ',send_message,start,Starting text\n'
-            'X,begin_block,,\n'
-            ',send_message,,Some text 1\n'
-            ',send_message,,Some text 2\n'
-            ',end_block,,\n'
-            ',send_message,X,Following text\n'
+            "row_id,type,from,message_text\n"
+            ",send_message,start,Starting text\n"
+            "X,begin_block,,\n"
+            ",send_message,,Some text 1\n"
+            ",send_message,,Some text 2\n"
+            ",end_block,,\n"
+            ",send_message,X,Following text\n"
         )
-        messages_exp = ['Starting text','Some text 1','Some text 2','Following text']
+        messages_exp = ["Starting text", "Some text 1", "Some text 2", "Following text"]
         self.run_example(table_data, messages_exp)
 
     def test_block_with_goto(self):
         table_data = (
-            'row_id,type,from,condition,message_text\n'
-            '2,begin_block,start,,\n'
-            ',send_message,,,Some text\n'
-            ',end_block,,,\n'
-            '3,wait_for_response,2,,\n'
-            ',go_to,3,hello,2\n'
-            ',send_message,3,,Following text\n'
+            "row_id,type,from,condition,message_text\n"
+            "2,begin_block,start,,\n"
+            ",send_message,,,Some text\n"
+            ",end_block,,,\n"
+            "3,wait_for_response,2,,\n"
+            ",go_to,3,hello,2\n"
+            ",send_message,3,,Following text\n"
         )
-        messages_exp = ['Some text','Following text']
-        self.run_example(table_data, messages_exp, Context(inputs=['goodbye']))
-        messages_exp = ['Some text','Some text','Following text']
-        self.run_example(table_data, messages_exp, Context(inputs=['hello', 'goodbye']))
+        messages_exp = ["Some text", "Following text"]
+        self.run_example(table_data, messages_exp, Context(inputs=["goodbye"]))
+        messages_exp = ["Some text", "Some text", "Following text"]
+        self.run_example(table_data, messages_exp, Context(inputs=["hello", "goodbye"]))
 
     def test_basic_if(self):
         table_data = (
-            'row_id,type,from,include_if,message_text\n'
-            ',send_message,,,text1\n'
-            ',send_message,,FALSE,text2\n'
-            ',send_message,,something,text3\n'
-            ',send_message,,False,text4\n'
-            ',send_message,,{{1 == 0}},text5\n'
-            ',send_message,,{@1 == 0@},text6\n'
-            ',send_message,,{@1 == 1@},text7\n'
+            "row_id,type,from,include_if,message_text\n"
+            ",send_message,,,text1\n"
+            ",send_message,,FALSE,text2\n"
+            ",send_message,,something,text3\n"
+            ",send_message,,False,text4\n"
+            ",send_message,,{{1 == 0}},text5\n"
+            ",send_message,,{@1 == 0@},text6\n"
+            ",send_message,,{@1 == 1@},text7\n"
         )
-        messages_exp = ['text1', 'text3', 'text7']
+        messages_exp = ["text1", "text3", "text7"]
         self.run_example(table_data, messages_exp)
 
     def test_excluded_block_within_other_nodes(self):
         table_data = (
-            'row_id,type,from,include_if,message_text\n'
-            ',send_message,start,,Starting text\n'
-            ',begin_block,,FALSE,\n'
-            ',send_message,,,Skipped text\n'
-            ',send_message,,TRUE,Skipped text 2\n'  # Should be skipped anyway
-            ',end_block,,,\n'
-            ',send_message,,,Following text\n'
+            "row_id,type,from,include_if,message_text\n"
+            ",send_message,start,,Starting text\n"
+            ",begin_block,,FALSE,\n"
+            ",send_message,,,Skipped text\n"
+            ",send_message,,TRUE,Skipped text 2\n"  # Should be skipped anyway
+            ",end_block,,,\n"
+            ",send_message,,,Following text\n"
         )
-        messages_exp = ['Starting text','Following text']
+        messages_exp = ["Starting text", "Following text"]
         self.run_example(table_data, messages_exp)
 
     def test_excluded_for_block(self):
         table_data = (
-            'row_id,type,from,include_if,message_text\n'
-            ',begin_for,,FALSE,1;2\n'  # No loop var; but it's not parsed anyway
-            ',send_message,,,Skipped text\n'
-            ',end_for,,,\n'
-            ',send_message,,,Following text\n'
+            "row_id,type,from,include_if,message_text\n"
+            ",begin_for,,FALSE,1;2\n"  # No loop var; but it's not parsed anyway
+            ",send_message,,,Skipped text\n"
+            ",end_for,,,\n"
+            ",send_message,,,Following text\n"
         )
-        messages_exp = ['Following text']
+        messages_exp = ["Following text"]
         self.run_example(table_data, messages_exp)
 
     def test_excluded_block_with_nested_stuff(self):
         table_data = (
-            'row_id,type,from,include_if,message_text\n'
-            ',begin_block,,FALSE,\n'
-            ',begin_block,,,\n'
-            ',send_message,,,Skipped text\n'
-            ',begin_for,,,1;2;3\n'  # No loop var; but it's not parsed anyway
-            ',send_message,,,{{i}}. Some text\n'
-            ',end_for,,,\n'
-            ',end_block,,,\n'
-            ',begin_for,,,A;B\n'
-            ',send_message,,,{{i}}. Some other text\n'
-            ',end_for,,,\n'
-            ',end_block,,,\n'
-            ',send_message,,,Following text\n'
+            "row_id,type,from,include_if,message_text\n"
+            ",begin_block,,FALSE,\n"
+            ",begin_block,,,\n"
+            ",send_message,,,Skipped text\n"
+            ",begin_for,,,1;2;3\n"  # No loop var; but it's not parsed anyway
+            ",send_message,,,{{i}}. Some text\n"
+            ",end_for,,,\n"
+            ",end_block,,,\n"
+            ",begin_for,,,A;B\n"
+            ",send_message,,,{{i}}. Some other text\n"
+            ",end_for,,,\n"
+            ",end_block,,,\n"
+            ",send_message,,,Following text\n"
         )
-        messages_exp = ['Following text']
+        messages_exp = ["Following text"]
         self.run_example(table_data, messages_exp)
 
 
 class TestMultiExitBlocks(TestBlocks):
-
     def test_split_by_value(self):
         table_data = (
-            'row_id,type,from,condition,message_text\n'
-            'X,begin_block,,,\n'
-            '1,split_by_value,,,@my_field\n'
-            ',send_message,1,Value,It has the value\n'
-            ',end_block,,,\n'
-            ',send_message,X,,Following text\n'
+            "row_id,type,from,condition,message_text\n"
+            "X,begin_block,,,\n"
+            "1,split_by_value,,,@my_field\n"
+            ",send_message,1,Value,It has the value\n"
+            ",end_block,,,\n"
+            ",send_message,X,,Following text\n"
         )
-        messages_exp = ['It has the value','Following text']
-        self.run_example(table_data, messages_exp, Context(variables={'@my_field' : 'Value'}))
-        messages_exp = ['Following text']
-        self.run_example(table_data, messages_exp, Context(variables={'@my_field' : 'Other'}))
+        messages_exp = ["It has the value", "Following text"]
+        self.run_example(
+            table_data, messages_exp, Context(variables={"@my_field": "Value"})
+        )
+        messages_exp = ["Following text"]
+        self.run_example(
+            table_data, messages_exp, Context(variables={"@my_field": "Other"})
+        )
 
     def test_split_by_value_hard_loose_exit(self):
         table_data = (
-            'row_id,type,from,condition,message_text\n'
-            'X,begin_block,,,\n'
-            '1,split_by_value,,,@my_field\n'
-            ',send_message,1,Value,It has the value\n'
-            ',hard_exit,1,Value2,\n'
-            ',loose_exit,1,Value3,\n'
-            ',end_block,,,\n'
-            ',send_message,X,,Following text\n'
+            "row_id,type,from,condition,message_text\n"
+            "X,begin_block,,,\n"
+            "1,split_by_value,,,@my_field\n"
+            ",send_message,1,Value,It has the value\n"
+            ",hard_exit,1,Value2,\n"
+            ",loose_exit,1,Value3,\n"
+            ",end_block,,,\n"
+            ",send_message,X,,Following text\n"
         )
-        messages_exp = ['It has the value','Following text']
-        self.run_example(table_data, messages_exp, Context(variables={'@my_field' : 'Value'}))
+        messages_exp = ["It has the value", "Following text"]
+        self.run_example(
+            table_data, messages_exp, Context(variables={"@my_field": "Value"})
+        )
         messages_exp = []
-        self.run_example(table_data, messages_exp, Context(variables={'@my_field' : 'Value2'}))
-        messages_exp = ['Following text']
-        self.run_example(table_data, messages_exp, Context(variables={'@my_field' : 'Value3'}))
-        messages_exp = ['Following text']
-        self.run_example(table_data, messages_exp, Context(variables={'@my_field' : 'Other'}))
+        self.run_example(
+            table_data, messages_exp, Context(variables={"@my_field": "Value2"})
+        )
+        messages_exp = ["Following text"]
+        self.run_example(
+            table_data, messages_exp, Context(variables={"@my_field": "Value3"})
+        )
+        messages_exp = ["Following text"]
+        self.run_example(
+            table_data, messages_exp, Context(variables={"@my_field": "Other"})
+        )
 
     def test_wait_for_response(self):
         table_data = (
-            'row_id,type,from,condition,message_text,no_response\n'
-            'X,begin_block,,,,\n'
-            '1,wait_for_response,,,,60\n'
-            ',send_message,1,Value,It has the value,\n'
-            ',send_message,1,No Response,No Response,\n'
-            ',end_block,,,\n'
-            ',send_message,1,,Other,\n'
-            ',send_message,X,,Following text,\n'
+            "row_id,type,from,condition,message_text,no_response\n"
+            "X,begin_block,,,,\n"
+            "1,wait_for_response,,,,60\n"
+            ",send_message,1,Value,It has the value,\n"
+            ",send_message,1,No Response,No Response,\n"
+            ",end_block,,,\n"
+            ",send_message,1,,Other,\n"
+            ",send_message,X,,Following text,\n"
         )
-        messages_exp = ['It has the value','Following text']
-        self.run_example(table_data, messages_exp, Context(inputs=['Value']))
-        messages_exp = ['No Response','Following text']
+        messages_exp = ["It has the value", "Following text"]
+        self.run_example(table_data, messages_exp, Context(inputs=["Value"]))
+        messages_exp = ["No Response", "Following text"]
         self.run_example(table_data, messages_exp, Context(inputs=[None]))
-        messages_exp = ['Other']
-        self.run_example(table_data, messages_exp, Context(inputs=['Something else']))
+        messages_exp = ["Other"]
+        self.run_example(table_data, messages_exp, Context(inputs=["Something else"]))
 
     def test_wait_for_response_hard_exits(self):
         table_data = (
-            'row_id,type,from,condition,message_text,no_response\n'
-            'X,begin_block,,,,\n'
-            '1,wait_for_response,,,,60\n'
-            ',send_message,1,Value,It has the value,\n'
-            ',hard_exit,,,,\n'
-            ',send_message,1,No Response,No Response,\n'
-            ',hard_exit,,,,\n'
-            ',end_block,,,\n'
-            ',send_message,X,,Following text,\n'
+            "row_id,type,from,condition,message_text,no_response\n"
+            "X,begin_block,,,,\n"
+            "1,wait_for_response,,,,60\n"
+            ",send_message,1,Value,It has the value,\n"
+            ",hard_exit,,,,\n"
+            ",send_message,1,No Response,No Response,\n"
+            ",hard_exit,,,,\n"
+            ",end_block,,,\n"
+            ",send_message,X,,Following text,\n"
         )
-        messages_exp = ['It has the value']
-        self.run_example(table_data, messages_exp, Context(inputs=['Value']))
-        messages_exp = ['No Response']
+        messages_exp = ["It has the value"]
+        self.run_example(table_data, messages_exp, Context(inputs=["Value"]))
+        messages_exp = ["No Response"]
         self.run_example(table_data, messages_exp, Context(inputs=[None]))
-        messages_exp = ['Following text']
-        self.run_example(table_data, messages_exp, Context(inputs=['Something else']))
+        messages_exp = ["Following text"]
+        self.run_example(table_data, messages_exp, Context(inputs=["Something else"]))
 
     def test_enter_flow(self):
         table_data = (
-            'row_id,type,from,condition,message_text\n'
-            ',send_message,start,,Starting text\n'
-            'X,begin_block,,,\n'
-            '1,start_new_flow,,,Some_flow\n'
-            ',send_message,1,completed,Completed\n'
-            ',end_block,,,\n'
-            ',send_message,X,,Following text\n'
+            "row_id,type,from,condition,message_text\n"
+            ",send_message,start,,Starting text\n"
+            "X,begin_block,,,\n"
+            "1,start_new_flow,,,Some_flow\n"
+            ",send_message,1,completed,Completed\n"
+            ",end_block,,,\n"
+            ",send_message,X,,Following text\n"
         )
         messages_exp = [
-            ('send_msg', 'Starting text'),
-            ('enter_flow','Some_flow'),
-            ('send_msg','Completed'),
-            ('send_msg','Following text'),
+            ("send_msg", "Starting text"),
+            ("enter_flow", "Some_flow"),
+            ("send_msg", "Completed"),
+            ("send_msg", "Following text"),
         ]
-        self.run_example_with_actions(table_data, messages_exp, Context(inputs=['completed']))
+        self.run_example_with_actions(
+            table_data, messages_exp, Context(inputs=["completed"])
+        )
         messages_exp = [
-            ('send_msg', 'Starting text'),
-            ('enter_flow','Some_flow'),
-            ('send_msg','Following text'),
+            ("send_msg", "Starting text"),
+            ("enter_flow", "Some_flow"),
+            ("send_msg", "Following text"),
         ]
-        self.run_example_with_actions(table_data, messages_exp, Context(inputs=['expired']))
+        self.run_example_with_actions(
+            table_data, messages_exp, Context(inputs=["expired"])
+        )
 
 
 class TestNoOpRow(TestBlocks):
-
     def test_basic_noop(self):
         table_data = (
-            'row_id,type,from,message_text\n'
-            ',send_message,,Start message\n'
-            ',no_op,,\n'
-            ',send_message,,End message\n'
+            "row_id,type,from,message_text\n"
+            ",send_message,,Start message\n"
+            ",no_op,,\n"
+            ",send_message,,End message\n"
         )
-        messages_exp = ['Start message','End message']
+        messages_exp = ["Start message", "End message"]
         self.run_example(table_data, messages_exp)
 
     def test_multientry_noop(self):
         table_data = (
-            'row_id,type,from,condition,message_text\n'
-            '1,wait_for_response,,,\n'
-            '2,send_message,1,A,Text A\n'
-            '3,send_message,1,,Other\n'
-            ',no_op,2;3,,\n'
-            ',send_message,,,End message\n'
+            "row_id,type,from,condition,message_text\n"
+            "1,wait_for_response,,,\n"
+            "2,send_message,1,A,Text A\n"
+            "3,send_message,1,,Other\n"
+            ",no_op,2;3,,\n"
+            ",send_message,,,End message\n"
         )
-        messages_exp = ['Text A','End message']
+        messages_exp = ["Text A", "End message"]
         self.run_example(table_data, messages_exp, context=Context(inputs=["A"]))
-        messages_exp = ['Other','End message']
-        self.run_example(table_data, messages_exp, context=Context(inputs=["something"]))
+        messages_exp = ["Other", "End message"]
+        self.run_example(
+            table_data, messages_exp, context=Context(inputs=["something"])
+        )
 
     def test_multiexit_noop(self):
         table_data = (
-            'row_id,type,from,condition_value,condition_variable,message_text\n'
-            ',send_message,,,,Start message\n'
-            '1,no_op,,,,\n'
-            ',send_message,1,A,@field,Text A\n'
-            ',send_message,1,,@field,Other\n'
-            ',send_message,1,B,@field,Text B\n'
+            "row_id,type,from,condition_value,condition_variable,message_text\n"
+            ",send_message,,,,Start message\n"
+            "1,no_op,,,,\n"
+            ",send_message,1,A,@field,Text A\n"
+            ",send_message,1,,@field,Other\n"
+            ",send_message,1,B,@field,Text B\n"
         )
-        messages_exp = ['Start message','Text A']
-        self.run_example(table_data, messages_exp, context=Context(variables={'@field':"A"}))
-        messages_exp = ['Start message','Text B']
-        self.run_example(table_data, messages_exp, context=Context(variables={'@field':"B"}))
-        messages_exp = ['Start message','Other']
-        self.run_example(table_data, messages_exp, context=Context(variables={'@field':"something"}))
+        messages_exp = ["Start message", "Text A"]
+        self.run_example(
+            table_data, messages_exp, context=Context(variables={"@field": "A"})
+        )
+        messages_exp = ["Start message", "Text B"]
+        self.run_example(
+            table_data, messages_exp, context=Context(variables={"@field": "B"})
+        )
+        messages_exp = ["Start message", "Other"]
+        self.run_example(
+            table_data, messages_exp, context=Context(variables={"@field": "something"})
+        )
 
     def test_multiexit_noop2(self):
         # only two rows are swapped, compared to previous case
         table_data = (
-            'row_id,type,from,condition_value,condition_variable,message_text\n'
-            ',send_message,,,,Start message\n'
-            '1,no_op,,,,\n'
-            ',send_message,1,,@field,Other\n'
-            ',send_message,1,A,@field,Text A\n'
-            ',send_message,1,B,@field,Text B\n'
+            "row_id,type,from,condition_value,condition_variable,message_text\n"
+            ",send_message,,,,Start message\n"
+            "1,no_op,,,,\n"
+            ",send_message,1,,@field,Other\n"
+            ",send_message,1,A,@field,Text A\n"
+            ",send_message,1,B,@field,Text B\n"
         )
-        messages_exp = ['Start message','Text A']
-        self.run_example(table_data, messages_exp, context=Context(variables={'@field':"A"}))
-        messages_exp = ['Start message','Text B']
-        self.run_example(table_data, messages_exp, context=Context(variables={'@field':"B"}))
-        messages_exp = ['Start message','Other']
-        self.run_example(table_data, messages_exp, context=Context(variables={'@field':"something"}))
+        messages_exp = ["Start message", "Text A"]
+        self.run_example(
+            table_data, messages_exp, context=Context(variables={"@field": "A"})
+        )
+        messages_exp = ["Start message", "Text B"]
+        self.run_example(
+            table_data, messages_exp, context=Context(variables={"@field": "B"})
+        )
+        messages_exp = ["Start message", "Other"]
+        self.run_example(
+            table_data, messages_exp, context=Context(variables={"@field": "something"})
+        )
 
     def test_multientryexit_noop(self):
         # only two rows are swapped, compared to previous case
         table_data = (
-            'row_id,type,from,condition_value,condition_variable,message_text\n'
-            '1,wait_for_response,,,,\n'
-            '2,send_message,1,A,,Text 1A\n'
-            '3,send_message,1,,,Other\n'
-            '4,no_op,2;3,,,\n'
-            ',send_message,4,A,@field,Text 2A\n'
-            ',send_message,4,,@field,Other\n'
-            ',send_message,4,B,@field,Text 2B\n'
+            "row_id,type,from,condition_value,condition_variable,message_text\n"
+            "1,wait_for_response,,,,\n"
+            "2,send_message,1,A,,Text 1A\n"
+            "3,send_message,1,,,Other\n"
+            "4,no_op,2;3,,,\n"
+            ",send_message,4,A,@field,Text 2A\n"
+            ",send_message,4,,@field,Other\n"
+            ",send_message,4,B,@field,Text 2B\n"
         )
-        messages_exp = ['Text 1A','Text 2A']
-        self.run_example(table_data, messages_exp, context=Context(inputs=["A"], variables={'@field':"A"}))
-        messages_exp = ['Text 1A','Text 2B']
-        self.run_example(table_data, messages_exp, context=Context(inputs=["A"], variables={'@field':"B"}))
-        messages_exp = ['Text 1A','Other']
-        self.run_example(table_data, messages_exp, context=Context(inputs=["A"], variables={'@field':"something"}))
-        messages_exp = ['Other','Text 2A']
-        self.run_example(table_data, messages_exp, context=Context(inputs=["something"], variables={'@field':"A"}))
-        messages_exp = ['Other','Text 2B']
-        self.run_example(table_data, messages_exp, context=Context(inputs=["something"], variables={'@field':"B"}))
-        messages_exp = ['Other','Other']
-        self.run_example(table_data, messages_exp, context=Context(inputs=["something"], variables={'@field':"something"}))
+        messages_exp = ["Text 1A", "Text 2A"]
+        self.run_example(
+            table_data,
+            messages_exp,
+            context=Context(inputs=["A"], variables={"@field": "A"}),
+        )
+        messages_exp = ["Text 1A", "Text 2B"]
+        self.run_example(
+            table_data,
+            messages_exp,
+            context=Context(inputs=["A"], variables={"@field": "B"}),
+        )
+        messages_exp = ["Text 1A", "Other"]
+        self.run_example(
+            table_data,
+            messages_exp,
+            context=Context(inputs=["A"], variables={"@field": "something"}),
+        )
+        messages_exp = ["Other", "Text 2A"]
+        self.run_example(
+            table_data,
+            messages_exp,
+            context=Context(inputs=["something"], variables={"@field": "A"}),
+        )
+        messages_exp = ["Other", "Text 2B"]
+        self.run_example(
+            table_data,
+            messages_exp,
+            context=Context(inputs=["something"], variables={"@field": "B"}),
+        )
+        messages_exp = ["Other", "Other"]
+        self.run_example(
+            table_data,
+            messages_exp,
+            context=Context(inputs=["something"], variables={"@field": "something"}),
+        )
 
     def test_noop_in_block_loose(self):
         # only two rows are swapped, compared to previous case
         table_data = (
-            'row_id,type,from,condition_value,condition_variable,message_text\n'
-            'X,begin_block,,,,\n'
-            ',send_message,,,,Start message\n'
-            '1,no_op,,,,\n'
-            ',end_block,,,,\n'
-            ',send_message,,,,End message\n'
+            "row_id,type,from,condition_value,condition_variable,message_text\n"
+            "X,begin_block,,,,\n"
+            ",send_message,,,,Start message\n"
+            "1,no_op,,,,\n"
+            ",end_block,,,,\n"
+            ",send_message,,,,End message\n"
         )
-        messages_exp = ['Start message','End message']
+        messages_exp = ["Start message", "End message"]
         self.run_example(table_data, messages_exp)
 
     def test_noop_in_block_notloose(self):
         # only two rows are swapped, compared to previous case
         table_data = (
-            'row_id,type,from,condition_value,condition_variable,message_text\n'
-            'X,begin_block,,,,\n'
-            ',send_message,,,,Start message\n'
-            '1,no_op,,,,\n'
-            ',send_message,,,,End message\n'
-            ',end_block,,,,\n'
-            ',send_message,,,,End message 2\n'
+            "row_id,type,from,condition_value,condition_variable,message_text\n"
+            "X,begin_block,,,,\n"
+            ",send_message,,,,Start message\n"
+            "1,no_op,,,,\n"
+            ",send_message,,,,End message\n"
+            ",end_block,,,,\n"
+            ",send_message,,,,End message 2\n"
         )
-        messages_exp = ['Start message','End message','End message 2']
+        messages_exp = ["Start message", "End message", "End message 2"]
         self.run_example(table_data, messages_exp)
 
     def test_noop_in_block2(self):
         # only two rows are swapped, compared to previous case
         table_data = (
-            'row_id,type,from,condition_value,condition_variable,message_text\n'
-            'X,begin_block,,,,\n'
-            ',send_message,,,,Start message\n'
-            '1,no_op,,,,\n'
-            ',loose_exit,1,,@field,\n'
-            ',hard_exit,1,A,@field,\n'
-            ',loose_exit,1,B,@field,\n'
-            ',end_block,,,,\n'
-            ',send_message,,,,End Message\n'
+            "row_id,type,from,condition_value,condition_variable,message_text\n"
+            "X,begin_block,,,,\n"
+            ",send_message,,,,Start message\n"
+            "1,no_op,,,,\n"
+            ",loose_exit,1,,@field,\n"
+            ",hard_exit,1,A,@field,\n"
+            ",loose_exit,1,B,@field,\n"
+            ",end_block,,,,\n"
+            ",send_message,,,,End Message\n"
         )
-        messages_exp = ['Start message']
-        self.run_example(table_data, messages_exp, context=Context(variables={'@field':"A"}))
-        messages_exp = ['Start message','End Message']
-        self.run_example(table_data, messages_exp, context=Context(variables={'@field':"B"}))
-        messages_exp = ['Start message','End Message']
-        self.run_example(table_data, messages_exp, context=Context(variables={'@field':"something"}))
+        messages_exp = ["Start message"]
+        self.run_example(
+            table_data, messages_exp, context=Context(variables={"@field": "A"})
+        )
+        messages_exp = ["Start message", "End Message"]
+        self.run_example(
+            table_data, messages_exp, context=Context(variables={"@field": "B"})
+        )
+        messages_exp = ["Start message", "End Message"]
+        self.run_example(
+            table_data, messages_exp, context=Context(variables={"@field": "something"})
+        )
 
     def test_multientry_block(self):
         table_data = (
-            'row_id,type,from,condition,message_text\n'
-            '1,wait_for_response,start,,\n'
-            '2,send_message,1,A,Message A\n'
-            '3,send_message,1,,Other\n'
-            'X,begin_block,2;3,,\n'
-            ',send_message,,,Some text 1\n'
-            ',end_block,,,\n'
-            ',send_message,,,Following text\n'
+            "row_id,type,from,condition,message_text\n"
+            "1,wait_for_response,start,,\n"
+            "2,send_message,1,A,Message A\n"
+            "3,send_message,1,,Other\n"
+            "X,begin_block,2;3,,\n"
+            ",send_message,,,Some text 1\n"
+            ",end_block,,,\n"
+            ",send_message,,,Following text\n"
         )
-        messages_exp = ['Message A','Some text 1','Following text']
+        messages_exp = ["Message A", "Some text 1", "Following text"]
         self.run_example(table_data, messages_exp, context=Context(inputs=["A"]))
-        messages_exp = ['Other','Some text 1','Following text']
-        self.run_example(table_data, messages_exp, context=Context(inputs=["something"]))
+        messages_exp = ["Other", "Some text 1", "Following text"]
+        self.run_example(
+            table_data, messages_exp, context=Context(inputs=["something"])
+        )
 
 
 class TestFlowParser(unittest.TestCase):
@@ -887,7 +1019,7 @@ class TestFlowParser(unittest.TestCase):
         # print(json.dumps(output_flow, indent=2))
 
         # Load the expected output flow
-        with open(TESTS_ROOT / "output/all_test_flows.json", 'r') as file:
+        with open(TESTS_ROOT / "output/all_test_flows.json", "r") as file:
             output_exp = json.load(file)
         for flow in output_exp["flows"]:
             if flow["name"] == flow_name:
@@ -904,7 +1036,9 @@ class TestFlowParser(unittest.TestCase):
         new_rows = flow_container.to_rows()
         # Now convert the sheet back into a flow
         sheet_parser = MockSheetParser(None, new_rows)
-        parser2 = FlowParser(RapidProContainer(), flow_name=flow_name, sheet_parser=sheet_parser)
+        parser2 = FlowParser(
+            RapidProContainer(), flow_name=flow_name, sheet_parser=sheet_parser
+        )
         flow_container = parser2.parse()
         new_output_flow = flow_container.render()
 
@@ -913,101 +1047,138 @@ class TestFlowParser(unittest.TestCase):
         self.assertEqual(new_actions, actions_exp)
 
     def test_no_switch_nodes(self):
-        self.run_example('input/no_switch_nodes.csv', 'no_switch_nodes', Context())
+        self.run_example("input/no_switch_nodes.csv", "no_switch_nodes", Context())
 
     def test_no_switch_nodes_without_row_ids(self):
-        self.run_example('input/no_switch_nodes_without_row_ids.csv', 'no_switch_nodes', Context())
+        self.run_example(
+            "input/no_switch_nodes_without_row_ids.csv", "no_switch_nodes", Context()
+        )
 
     def test_switch_nodes(self):
-        context = Context(inputs=['b', 'expired'])
-        self.run_example('input/switch_nodes.csv', 'switch_nodes', context)
+        context = Context(inputs=["b", "expired"])
+        self.run_example("input/switch_nodes.csv", "switch_nodes", context)
 
-        context = Context(inputs=['a', 'completed'],
-                variables = {
-                    "expression" : 'not a',
-                })
-        self.run_example('input/switch_nodes.csv', 'switch_nodes', context)
+        context = Context(
+            inputs=["a", "completed"],
+            variables={
+                "expression": "not a",
+            },
+        )
+        self.run_example("input/switch_nodes.csv", "switch_nodes", context)
 
-        context = Context(inputs=['a', 'completed'],
-                group_names=['wrong group'],
-                variables = {
-                    "expression" : 'a',
-                    "@contact.name" : 'a',
-                    "@results.result_wfr" : 'a',
-                })
-        self.run_example('input/switch_nodes.csv', 'switch_nodes', context)
+        context = Context(
+            inputs=["a", "completed"],
+            group_names=["wrong group"],
+            variables={
+                "expression": "a",
+                "@contact.name": "a",
+                "@results.result_wfr": "a",
+            },
+        )
+        self.run_example("input/switch_nodes.csv", "switch_nodes", context)
 
-        context = Context(inputs=['a', 'completed', 'other'],
-                group_names=['test group'],
-                variables = {
-                    "expression" : 'a',
-                    "@contact.name" : 'a',
-                    "@results.result_wfr" : 'a',
-                })
-        self.run_example('input/switch_nodes.csv', 'switch_nodes', context)
+        context = Context(
+            inputs=["a", "completed", "other"],
+            group_names=["test group"],
+            variables={
+                "expression": "a",
+                "@contact.name": "a",
+                "@results.result_wfr": "a",
+            },
+        )
+        self.run_example("input/switch_nodes.csv", "switch_nodes", context)
 
-        context = Context(inputs=['a', 'completed', 'a'],
-                random_choices=[0],
-                group_names=['test group'],
-                variables = {
-                    "expression" : 'a',
-                    "@contact.name" : 'a',
-                    "@results.result_wfr" : 'a',
-                })
-        self.run_example('input/switch_nodes.csv', 'switch_nodes', context)
+        context = Context(
+            inputs=["a", "completed", "a"],
+            random_choices=[0],
+            group_names=["test group"],
+            variables={
+                "expression": "a",
+                "@contact.name": "a",
+                "@results.result_wfr": "a",
+            },
+        )
+        self.run_example("input/switch_nodes.csv", "switch_nodes", context)
 
-        context = Context(inputs=['a', 'completed', 'a'],
-                random_choices=[2],
-                group_names=['test group'],
-                variables = {
-                    "expression" : 'a',
-                    "@contact.name" : 'a',
-                    "@results.result_wfr" : 'a',
-                })
-        self.run_example('input/switch_nodes.csv', 'switch_nodes', context)
+        context = Context(
+            inputs=["a", "completed", "a"],
+            random_choices=[2],
+            group_names=["test group"],
+            variables={
+                "expression": "a",
+                "@contact.name": "a",
+                "@results.result_wfr": "a",
+            },
+        )
+        self.run_example("input/switch_nodes.csv", "switch_nodes", context)
 
-        context = Context(inputs=['a', 'completed', None, None],
-                group_names=['test group'],
-                variables = {
-                    "expression" : 'a',
-                    "@contact.name" : 'a',
-                    "@results.result_wfr" : 'a',
-                })
-        self.run_example('input/switch_nodes.csv', 'switch_nodes', context)
+        context = Context(
+            inputs=["a", "completed", None, None],
+            group_names=["test group"],
+            variables={
+                "expression": "a",
+                "@contact.name": "a",
+                "@results.result_wfr": "a",
+            },
+        )
+        self.run_example("input/switch_nodes.csv", "switch_nodes", context)
 
     def test_loop_from_start(self):
-        context = Context(inputs=['b'])
-        self.run_example('input/loop_from_start.csv', 'loop_from_start', context)
+        context = Context(inputs=["b"])
+        self.run_example("input/loop_from_start.csv", "loop_from_start", context)
 
-        context = Context(inputs=['a', 'b'])
-        self.run_example('input/loop_from_start.csv', 'loop_from_start', context)
+        context = Context(inputs=["a", "b"])
+        self.run_example("input/loop_from_start.csv", "loop_from_start", context)
 
     def test_rejoin(self):
         context = Context(random_choices=[0])
-        self.run_example('input/rejoin.csv', 'rejoin', context)
+        self.run_example("input/rejoin.csv", "rejoin", context)
 
         context = Context(random_choices=[1])
-        self.run_example('input/rejoin.csv', 'rejoin', context)
+        self.run_example("input/rejoin.csv", "rejoin", context)
 
         context = Context(random_choices=[2])
-        self.run_example('input/rejoin.csv', 'rejoin', context)
+        self.run_example("input/rejoin.csv", "rejoin", context)
 
     def test_loop_and_multiple_conditions(self):
-        context = Context(inputs=['adfgyh'], random_choices=[0])
-        self.run_example('input/loop_and_multiple_conditions.csv', 'loop_and_multiple_conditions', context)
+        context = Context(inputs=["adfgyh"], random_choices=[0])
+        self.run_example(
+            "input/loop_and_multiple_conditions.csv",
+            "loop_and_multiple_conditions",
+            context,
+        )
 
-        context = Context(inputs=['other'], random_choices=[0])
-        self.run_example('input/loop_and_multiple_conditions.csv', 'loop_and_multiple_conditions', context)
+        context = Context(inputs=["other"], random_choices=[0])
+        self.run_example(
+            "input/loop_and_multiple_conditions.csv",
+            "loop_and_multiple_conditions",
+            context,
+        )
 
         context = Context(random_choices=[1])
-        self.run_example('input/loop_and_multiple_conditions.csv', 'loop_and_multiple_conditions', context)
+        self.run_example(
+            "input/loop_and_multiple_conditions.csv",
+            "loop_and_multiple_conditions",
+            context,
+        )
 
-        context = Context(inputs=['other'], random_choices=[2])
-        self.run_example('input/loop_and_multiple_conditions.csv', 'loop_and_multiple_conditions', context)
+        context = Context(inputs=["other"], random_choices=[2])
+        self.run_example(
+            "input/loop_and_multiple_conditions.csv",
+            "loop_and_multiple_conditions",
+            context,
+        )
 
-        context = Context(inputs=['b', 'a'], random_choices=[2])
-        self.run_example('input/loop_and_multiple_conditions.csv', 'loop_and_multiple_conditions', context)
+        context = Context(inputs=["b", "a"], random_choices=[2])
+        self.run_example(
+            "input/loop_and_multiple_conditions.csv",
+            "loop_and_multiple_conditions",
+            context,
+        )
 
-        context = Context(inputs=['b', 'b', 'c'], random_choices=[2])
-        self.run_example('input/loop_and_multiple_conditions.csv', 'loop_and_multiple_conditions', context)
-
+        context = Context(inputs=["b", "b", "c"], random_choices=[2])
+        self.run_example(
+            "input/loop_and_multiple_conditions.csv",
+            "loop_and_multiple_conditions",
+            context,
+        )

--- a/tests/test_flowparser_reverse.py
+++ b/tests/test_flowparser_reverse.py
@@ -13,16 +13,19 @@ class TestFlowParserReverse(unittest.TestCase):
         model_dict = model.dict()
         model_exp_dict = model_exp.dict()
         for edge, edge_exp in zip(model_dict["edges"], model_exp_dict["edges"]):
-            if edge["condition"]["variable"] == "@input.text" and edge_exp["condition"]["variable"] == "":
+            if (
+                edge["condition"]["variable"] == "@input.text"
+                and edge_exp["condition"]["variable"] == ""
+            ):
                 # @input.text is implicit when left blank.
                 edge_exp["condition"]["variable"] = "@input.text"
         if model.node_uuid and not model_exp.node_uuid:
             # If no explicit node UUID was specified, don't compare the generated node uuid
-            model_dict['node_uuid'] = ''
+            model_dict["node_uuid"] = ""
         if model.obj_id and not model_exp.obj_id:
             # If no explicit object UUID was specified, don't compare
-            model_dict['obj_id'] = ''
-        for field in ['image', 'audio', 'video', 'obj_name', 'node_name', 'ui_type']:
+            model_dict["obj_id"] = ""
+        for field in ["image", "audio", "video", "obj_name", "node_name", "ui_type"]:
             # We ignore these. Attachments need to be rethought,
             # the other of these fields may be removed as well.
             model_dict.pop(field)
@@ -30,7 +33,7 @@ class TestFlowParserReverse(unittest.TestCase):
         # TODO: We have trailing '' quick replies here.
         # They get removed in the conversion process, but probably the RowParser
         # should already take care of them
-        model_exp_dict['choices'] = [qr for qr in model_exp_dict['choices'] if qr]
+        model_exp_dict["choices"] = [qr for qr in model_exp_dict["choices"] if qr]
         self.assertEqual(model_dict, model_exp_dict)
 
     def run_example(self, filename, flow_name):
@@ -47,19 +50,21 @@ class TestFlowParserReverse(unittest.TestCase):
             self.compare_models_leniently(model, model_exp)
 
     def test_no_switch_nodes(self):
-        self.run_example('input/no_switch_nodes.csv', 'no_switch_nodes')
+        self.run_example("input/no_switch_nodes.csv", "no_switch_nodes")
 
     def test_switch_nodes(self):
-        self.run_example('input/switch_nodes.csv', 'switch_nodes')
+        self.run_example("input/switch_nodes.csv", "switch_nodes")
 
     def test_loop_from_start(self):
-        self.run_example('input/loop_from_start.csv', 'loop_from_start')
+        self.run_example("input/loop_from_start.csv", "loop_from_start")
 
     def test_groups_and_flows(self):
-        self.run_example('input/groups_and_flows.csv', 'groups_and_flows')
+        self.run_example("input/groups_and_flows.csv", "groups_and_flows")
 
     def test_loop_and_multiple_conditions(self):
-        self.run_example('input/loop_and_multiple_conditions.csv', 'loop_and_multiple_conditions')
+        self.run_example(
+            "input/loop_and_multiple_conditions.csv", "loop_and_multiple_conditions"
+        )
 
     def test_rejoin(self):
-        self.run_example('input/rejoin.csv', 'rejoin')
+        self.run_example("input/rejoin.csv", "rejoin")

--- a/tests/test_full_rows.py
+++ b/tests/test_full_rows.py
@@ -7,59 +7,78 @@ from tests.mocks import MockCellParser
 
 
 input1 = {
-    'row_id' : '1',
-    'type' : 'send_message',
-    'from' : 'start',
-    'condition_value' : '3',
-    'condition_var' : '@fields.name',
-    'condition_type' : 'has_phrase',
-    'condition_name' : '',
-    'message_text' : 'Text of message',
-    'choices' : ['Answer 1', 'Answer 2'],
-    'ui_position' : '',  # CellParser is unaware of types, so '' is NOT turned into a list by the cell parser.
+    "row_id": "1",
+    "type": "send_message",
+    "from": "start",
+    "condition_value": "3",
+    "condition_var": "@fields.name",
+    "condition_type": "has_phrase",
+    "condition_name": "",
+    "message_text": "Text of message",
+    "choices": ["Answer 1", "Answer 2"],
+    "ui_position": "",  # CellParser is unaware of types, so '' is NOT turned into a list by the cell parser.
 }
 
-output1_exp = FlowRowModel(**{
-    'row_id' : '1',
-    'type' : 'send_message',
-    'edges' : [
-        {
-            'from_': 'start',
-            'condition': {'value':'3', 'variable':'@fields.name', 'type':'has_phrase', 'name':''},
-        }
-    ],
-    'mainarg_message_text' : 'Text of message',
-    'choices' : ['Answer 1', 'Answer 2'],
-    'ui_position' : [],  # The RowParser converts '' into []
-})
+output1_exp = FlowRowModel(
+    **{
+        "row_id": "1",
+        "type": "send_message",
+        "edges": [
+            {
+                "from_": "start",
+                "condition": {
+                    "value": "3",
+                    "variable": "@fields.name",
+                    "type": "has_phrase",
+                    "name": "",
+                },
+            }
+        ],
+        "mainarg_message_text": "Text of message",
+        "choices": ["Answer 1", "Answer 2"],
+        "ui_position": [],  # The RowParser converts '' into []
+    }
+)
 
 
 input2 = {
-    'row_id' : '1',
-    'type' : 'send_message',
-    'from' : 'start',
-    'condition_value' : ['3', '5'],
-    'condition_var' : '@fields.name',
-    'condition_type' : 'has_phrase',
-    'condition_name' : '',
-    'message_text' : 'Text of message',
+    "row_id": "1",
+    "type": "send_message",
+    "from": "start",
+    "condition_value": ["3", "5"],
+    "condition_var": "@fields.name",
+    "condition_type": "has_phrase",
+    "condition_name": "",
+    "message_text": "Text of message",
 }
 
-output2_exp = FlowRowModel(**{
-    'row_id' : '1',
-    'type' : 'send_message',
-    'edges' : [
-        {
-            'from_': 'start',
-            'condition': {'value':'3', 'variable':'@fields.name', 'type':'has_phrase', 'name':''},
-        },
-        {
-            'from_': 'start',
-            'condition': {'value':'5', 'variable':'@fields.name', 'type':'has_phrase', 'name':''},
-        },
-    ],
-    'mainarg_message_text' : 'Text of message',
-})
+output2_exp = FlowRowModel(
+    **{
+        "row_id": "1",
+        "type": "send_message",
+        "edges": [
+            {
+                "from_": "start",
+                "condition": {
+                    "value": "3",
+                    "variable": "@fields.name",
+                    "type": "has_phrase",
+                    "name": "",
+                },
+            },
+            {
+                "from_": "start",
+                "condition": {
+                    "value": "5",
+                    "variable": "@fields.name",
+                    "type": "has_phrase",
+                    "name": "",
+                },
+            },
+        ],
+        "mainarg_message_text": "Text of message",
+    }
+)
 
 
 # This is an interesting case.
@@ -67,100 +86,119 @@ output2_exp = FlowRowModel(**{
 # as one from with a condition and one unconditional one.
 # To realize that, however, we'd have to decouple from from its conditions.
 input3 = {
-    'row_id' : '1',
-    'type' : 'send_message',
-    'from' : ['start', '5'],
-    'condition_value' : '3',
-    'condition_var' : '@fields.name',
-    'condition_type' : 'has_phrase',
-    'condition_name' : '',
-    'message_text' : 'Text of message',
+    "row_id": "1",
+    "type": "send_message",
+    "from": ["start", "5"],
+    "condition_value": "3",
+    "condition_var": "@fields.name",
+    "condition_type": "has_phrase",
+    "condition_name": "",
+    "message_text": "Text of message",
 }
 
-output3_exp = FlowRowModel(**{
-    'row_id' : '1',
-    'type' : 'send_message',
-    'edges' : [
-        {
-            'from_': 'start',
-            'condition': {'value':'3', 'variable':'@fields.name', 'type':'has_phrase', 'name':''},
-        },
-        {
-            'from_': '5',
-            'condition': {'value':'3', 'variable':'@fields.name', 'type':'has_phrase', 'name':''},
-        },
-    ],
-    'mainarg_message_text' : 'Text of message',
-})
+output3_exp = FlowRowModel(
+    **{
+        "row_id": "1",
+        "type": "send_message",
+        "edges": [
+            {
+                "from_": "start",
+                "condition": {
+                    "value": "3",
+                    "variable": "@fields.name",
+                    "type": "has_phrase",
+                    "name": "",
+                },
+            },
+            {
+                "from_": "5",
+                "condition": {
+                    "value": "3",
+                    "variable": "@fields.name",
+                    "type": "has_phrase",
+                    "name": "",
+                },
+            },
+        ],
+        "mainarg_message_text": "Text of message",
+    }
+)
 
 
 input4 = {
-    'row_id' : '1',
-    'type' : 'add_to_group',
-    'from' : 'start',
-    'message_text' : 'Group Name',
+    "row_id": "1",
+    "type": "add_to_group",
+    "from": "start",
+    "message_text": "Group Name",
 }
 
-output4_exp = FlowRowModel(**{
-    'row_id' : '1',
-    'type' : 'add_to_group',
-    'edges' : [
-        {
-            'from_': 'start',
-        },
-    ],
-    'mainarg_groups' : ['Group Name'],
-})
+output4_exp = FlowRowModel(
+    **{
+        "row_id": "1",
+        "type": "add_to_group",
+        "edges": [
+            {
+                "from_": "start",
+            },
+        ],
+        "mainarg_groups": ["Group Name"],
+    }
+)
 
 
 input5 = {
-    'row_id' : '1',
-    'type' : 'go_to',
-    'from' : 'start',
-    'message_text' : ['5', '2', '3'],
+    "row_id": "1",
+    "type": "go_to",
+    "from": "start",
+    "message_text": ["5", "2", "3"],
 }
 
-output5_exp = FlowRowModel(**{
-    'row_id' : '1',
-    'type' : 'go_to',
-    'edges' : [
-        {
-            'from_': 'start',
-        },
-    ],
-    'mainarg_destination_row_ids' : ['5', '2', '3'],
-})
+output5_exp = FlowRowModel(
+    **{
+        "row_id": "1",
+        "type": "go_to",
+        "edges": [
+            {
+                "from_": "start",
+            },
+        ],
+        "mainarg_destination_row_ids": ["5", "2", "3"],
+    }
+)
 
 
 input6 = {
-    'row_id' : '1',
-    'type' : 'send_message',
-    'edges' : [
-        ['start', ['5']],
-        ['start', ['3', '@fields.name', 'has_phrase']]
-    ],
-    'message_text' : 'Text of message',
+    "row_id": "1",
+    "type": "send_message",
+    "edges": [["start", ["5"]], ["start", ["3", "@fields.name", "has_phrase"]]],
+    "message_text": "Text of message",
 }
 
-output6_exp = FlowRowModel(**{
-    'row_id' : '1',
-    'type' : 'send_message',
-    'edges' : [
-        {
-            'from_': 'start',
-            'condition': {'value':'5'},
-        },
-        {
-            'from_': 'start',
-            'condition': {'value':'3', 'variable':'@fields.name', 'type':'has_phrase', 'name':''},
-        },
-    ],
-    'mainarg_message_text' : 'Text of message',
-})
+output6_exp = FlowRowModel(
+    **{
+        "row_id": "1",
+        "type": "send_message",
+        "edges": [
+            {
+                "from_": "start",
+                "condition": {"value": "5"},
+            },
+            {
+                "from_": "start",
+                "condition": {
+                    "value": "3",
+                    "variable": "@fields.name",
+                    "type": "has_phrase",
+                    "name": "",
+                },
+            },
+        ],
+        "mainarg_message_text": "Text of message",
+    }
+)
 
 
 class TestDifferentWays(unittest.TestCase):
-
     def setUp(self):
         self.parser = RowParser(FlowRowModel, MockCellParser())
 
@@ -189,5 +227,5 @@ class TestDifferentWays(unittest.TestCase):
         self.assertEqual(output6, output6_exp)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -15,39 +15,39 @@ class TestImportExport(unittest.TestCase):
         self.data_dir = TESTS_ROOT / "data"
 
     def test_all_action_types(self):
-        actionFilenamesList = self.data_dir.glob('actions/*.json')
+        actionFilenamesList = self.data_dir.glob("actions/*.json")
         for filename in actionFilenamesList:
-            with open(filename, 'r') as f:
+            with open(filename, "r") as f:
                 action_data = json.load(f)
             action = Action.from_dict(action_data)
             render_output = action.render()
             self.assertEqual(render_output, action_data, msg=filename)
 
     def test_exits(self):
-        with open(self.data_dir / 'exits/exit.json', 'r') as f:
+        with open(self.data_dir / "exits/exit.json", "r") as f:
             data = json.load(f)
         exit = Exit.from_dict(data)
         render_output = exit.render()
         self.assertEqual(render_output, data)
 
     def test_groups(self):
-        with open(self.data_dir / 'groups/group.json', 'r') as f:
+        with open(self.data_dir / "groups/group.json", "r") as f:
             data = json.load(f)
         group = Group.from_dict(data)
         render_output = group.render()
         self.assertEqual(render_output, data)
 
     def test_cases(self):
-        with open(self.data_dir / 'routers/case.json', 'r') as f:
+        with open(self.data_dir / "routers/case.json", "r") as f:
             data = json.load(f)
         case = RouterCase.from_dict(data)
         render_output = case.render()
         self.assertEqual(render_output, data)
 
     def test_categories(self):
-        with open(self.data_dir / 'routers/category.json', 'r') as f:
+        with open(self.data_dir / "routers/category.json", "r") as f:
             data = json.load(f)
-        with open(self.data_dir / 'routers/exits.json', 'r') as f:
+        with open(self.data_dir / "routers/exits.json", "r") as f:
             exit_data = json.load(f)
         exits = [Exit.from_dict(exit) for exit in exit_data]
         category = RouterCategory.from_dict(data, exits)
@@ -59,11 +59,11 @@ class TestImportExport(unittest.TestCase):
         # within switch routers is always the last one.
         # This might change once we support "Expired" categories
         self.maxDiff = None
-        routerFilenamesList = self.data_dir.glob('routers/router_*.json')
+        routerFilenamesList = self.data_dir.glob("routers/router_*.json")
         for filename in routerFilenamesList:
-            with open(filename, 'r') as f:
+            with open(filename, "r") as f:
                 router_data = json.load(f)
-            with open(self.data_dir / 'routers/exits.json', 'r') as f:
+            with open(self.data_dir / "routers/exits.json", "r") as f:
                 exit_data = json.load(f)
             exits = [Exit.from_dict(exit) for exit in exit_data]
             router = BaseRouter.from_dict(router_data, exits)
@@ -72,9 +72,9 @@ class TestImportExport(unittest.TestCase):
 
     def test_all_node_types(self):
         self.maxDiff = None
-        nodeFilenamesList = self.data_dir.glob('nodes/node_*.json')
+        nodeFilenamesList = self.data_dir.glob("nodes/node_*.json")
         for filename in nodeFilenamesList:
-            with open(filename, 'r') as f:
+            with open(filename, "r") as f:
                 node_data = json.load(f)
             node = BaseNode.from_dict(node_data)
             render_output = node.render()
@@ -83,9 +83,9 @@ class TestImportExport(unittest.TestCase):
     def test_flow_containers(self):
         self.maxDiff = None
         # TODO: Add test with localization (of different objects) to ensure it is maintained
-        containerFilenamesList = self.data_dir.glob('containers/flow_container_*.json')
+        containerFilenamesList = self.data_dir.glob("containers/flow_container_*.json")
         for filename in containerFilenamesList:
-            with open(filename, 'r') as f:
+            with open(filename, "r") as f:
                 container_data = json.load(f)
             container = FlowContainer.from_dict(container_data)
             render_output = container.render()
@@ -94,9 +94,11 @@ class TestImportExport(unittest.TestCase):
 
     def test_rapidpro_containers(self):
         self.maxDiff = None
-        containerFilenamesList = self.data_dir.glob('containers/rapidpro_container_*.json')
+        containerFilenamesList = self.data_dir.glob(
+            "containers/rapidpro_container_*.json"
+        )
         for filename in containerFilenamesList:
-            with open(filename, 'r') as f:
+            with open(filename, "r") as f:
                 container_data = json.load(f)
             container = RapidProContainer.from_dict(container_data)
             render_output = container.render()
@@ -104,9 +106,9 @@ class TestImportExport(unittest.TestCase):
 
     def test_campaign_events(self):
         self.maxDiff = None
-        filenamesList = self.data_dir.glob('campaigns/event_*.json')
+        filenamesList = self.data_dir.glob("campaigns/event_*.json")
         for filename in filenamesList:
-            with open(filename, 'r') as f:
+            with open(filename, "r") as f:
                 data = json.load(f)
             event = CampaignEvent.from_dict(data)
             render_output = event.render()
@@ -114,9 +116,9 @@ class TestImportExport(unittest.TestCase):
 
     def test_campaigns(self):
         self.maxDiff = None
-        filenamesList = self.data_dir.glob('campaigns/campaign_*.json')
+        filenamesList = self.data_dir.glob("campaigns/campaign_*.json")
         for filename in filenamesList:
-            with open(filename, 'r') as f:
+            with open(filename, "r") as f:
                 data = json.load(f)
             campaign = Campaign.from_dict(data)
             render_output = campaign.render()

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -7,25 +7,39 @@ from rpft.rapidpro.models.nodes import BasicNode
 class TestNodes(unittest.TestCase):
     def setUp(self) -> None:
         self.basic_node = BasicNode()
-        self.basic_node.add_action(SendMessageAction(text='test_message_1', quick_replies=['qr01', 'qr02', 'qr03']))
-        self.basic_node.add_action(SendMessageAction(text='test_image_message', attachments=['image:image url']))
-        self.basic_node.add_action(SendMessageAction(text='test_audio_message', attachments=['audio:audio url']))
+        self.basic_node.add_action(
+            SendMessageAction(
+                text="test_message_1", quick_replies=["qr01", "qr02", "qr03"]
+            )
+        )
+        self.basic_node.add_action(
+            SendMessageAction(
+                text="test_image_message", attachments=["image:image url"]
+            )
+        )
+        self.basic_node.add_action(
+            SendMessageAction(
+                text="test_audio_message", attachments=["audio:audio url"]
+            )
+        )
 
-        self.basic_node.update_default_exit('test_destination_uuid')
+        self.basic_node.update_default_exit("test_destination_uuid")
 
     def test_basic_node(self):
         render_output = self.basic_node.render()
 
-        action_names = [a['text'] for a in render_output['actions']]
+        action_names = [a["text"] for a in render_output["actions"]]
 
-        action_1_index = action_names.index('test_message_1')
-        action_2_index = action_names.index('test_image_message')
-        action_3_index = action_names.index('test_audio_message')
+        action_1_index = action_names.index("test_message_1")
+        action_2_index = action_names.index("test_image_message")
+        action_3_index = action_names.index("test_audio_message")
 
-        self.assertEqual(render_output['actions'][action_1_index]['text'], 'test_message_1')
-        self.assertEqual(render_output['actions'][action_2_index]['text'], 'test_image_message')
-        self.assertEqual(render_output['actions'][action_3_index]['text'], 'test_audio_message')
-
-
-
-
+        self.assertEqual(
+            render_output["actions"][action_1_index]["text"], "test_message_1"
+        )
+        self.assertEqual(
+            render_output["actions"][action_2_index]["text"], "test_image_message"
+        )
+        self.assertEqual(
+            render_output["actions"][action_3_index]["text"], "test_audio_message"
+        )

--- a/tests/test_routers.py
+++ b/tests/test_routers.py
@@ -5,116 +5,185 @@ from rpft.rapidpro.models.routers import SwitchRouter, RandomRouter
 
 class TestRouters(unittest.TestCase):
     def setUp(self) -> None:
-        self.switch_router = SwitchRouter(operand='@input.text', result_name=None, wait_timeout=600)
-        self.switch_router.add_choice('@input.text', 'has_any_word', ['word'], 'Add', 'test_destination_1',
-                                      is_default=False)
-        self.switch_router.add_choice('@input.text', 'has_any_word', ['word'], 'Other', 'test_destination_2',
-                                      is_default=True)
-        self.switch_router.update_no_response_category('no_response_destination_uuid')
+        self.switch_router = SwitchRouter(
+            operand="@input.text", result_name=None, wait_timeout=600
+        )
+        self.switch_router.add_choice(
+            "@input.text",
+            "has_any_word",
+            ["word"],
+            "Add",
+            "test_destination_1",
+            is_default=False,
+        )
+        self.switch_router.add_choice(
+            "@input.text",
+            "has_any_word",
+            ["word"],
+            "Other",
+            "test_destination_2",
+            is_default=True,
+        )
+        self.switch_router.update_no_response_category("no_response_destination_uuid")
 
         self.random_router = RandomRouter()
-        self.random_router.add_choice('random_1', 'test_destination_1')
-        self.random_router.add_choice('random_2', 'test_destination_2')
-        self.random_router.add_choice('random_3', 'test_destination_3')
+        self.random_router.add_choice("random_1", "test_destination_1")
+        self.random_router.add_choice("random_2", "test_destination_2")
+        self.random_router.add_choice("random_3", "test_destination_3")
 
     def test_switch_router_render(self):
-
         render_output = self.switch_router.render()
 
-        for key in ['type', 'categories', 'cases', 'operand', 'default_category_uuid']:
+        for key in ["type", "categories", "cases", "operand", "default_category_uuid"]:
             self.assertIn(key, list(render_output.keys()))
 
-        self.assertEqual(render_output['type'], 'switch')
-        self.assertEqual(render_output['operand'], '@input.text')
-        self.assertEqual(render_output['cases'][0]['type'], 'has_any_word')
-        self.assertEqual(render_output['cases'][0]['arguments'], ['word'])
+        self.assertEqual(render_output["type"], "switch")
+        self.assertEqual(render_output["operand"], "@input.text")
+        self.assertEqual(render_output["cases"][0]["type"], "has_any_word")
+        self.assertEqual(render_output["cases"][0]["arguments"], ["word"])
 
-        self.assertEqual(len(render_output['categories']), 3)
-        self.assertEqual(render_output['categories'][0]['name'], 'Add')
+        self.assertEqual(len(render_output["categories"]), 3)
+        self.assertEqual(render_output["categories"][0]["name"], "Add")
 
-        self.assertIn('Add', [c['name'] for c in render_output['categories']])
-        self.assertIn('Other', [c['name'] for c in render_output['categories']])
-        self.assertIn('No Response', [c['name'] for c in render_output['categories']])
-        self.assertIn('wait', render_output)
-        self.assertEqual(render_output['wait']['timeout']['seconds'], 600)
-        no_response_category = [c for c in render_output['categories'] if c['name'] == 'No Response'][0]
-        self.assertEqual(render_output['wait']['timeout']['category_uuid'], no_response_category['uuid'])
+        self.assertIn("Add", [c["name"] for c in render_output["categories"]])
+        self.assertIn("Other", [c["name"] for c in render_output["categories"]])
+        self.assertIn("No Response", [c["name"] for c in render_output["categories"]])
+        self.assertIn("wait", render_output)
+        self.assertEqual(render_output["wait"]["timeout"]["seconds"], 600)
+        no_response_category = [
+            c for c in render_output["categories"] if c["name"] == "No Response"
+        ][0]
+        self.assertEqual(
+            render_output["wait"]["timeout"]["category_uuid"],
+            no_response_category["uuid"],
+        )
 
-        other_category_arr = [c for c in render_output['categories'] if c['name'] == 'Other']
+        other_category_arr = [
+            c for c in render_output["categories"] if c["name"] == "Other"
+        ]
 
-        self.assertEqual(render_output['default_category_uuid'], other_category_arr[0]['uuid'])
+        self.assertEqual(
+            render_output["default_category_uuid"], other_category_arr[0]["uuid"]
+        )
 
     def test_random_router_render(self):
-
         render_output = self.random_router.render()
 
-        self.assertEqual(render_output['type'], 'random')
-        for key in ['type', 'categories']:
+        self.assertEqual(render_output["type"], "random")
+        for key in ["type", "categories"]:
             self.assertIn(key, list(render_output.keys()))
 
-        category_names = [c['name'] for c in render_output['categories']]
+        category_names = [c["name"] for c in render_output["categories"]]
 
-        for name in ['random_1', 'random_2', 'random_3']:
+        for name in ["random_1", "random_2", "random_3"]:
             self.assertIn(name, category_names)
 
 
 class TestDuplicateChoices(unittest.TestCase):
-
     def test_switch_router_default(self):
-        switch_router = SwitchRouter(operand='@fields.field')
-        switch_router.add_choice('@fields.field', 'has_any_word', ['other'], 'Other', 'test_destination_1',
-                                      is_default=True)
-        switch_router.add_choice('@fields.field', 'has_any_word', ['word'], 'Word', 'test_destination_2',
-                                      is_default=False)
+        switch_router = SwitchRouter(operand="@fields.field")
+        switch_router.add_choice(
+            "@fields.field",
+            "has_any_word",
+            ["other"],
+            "Other",
+            "test_destination_1",
+            is_default=True,
+        )
+        switch_router.add_choice(
+            "@fields.field",
+            "has_any_word",
+            ["word"],
+            "Word",
+            "test_destination_2",
+            is_default=False,
+        )
         # Duplicate case with different destination
-        switch_router.add_choice('@fields.field', 'has_any_word', ['other'], 'Other', 'test_destination_3',
-                                      is_default=True)
+        switch_router.add_choice(
+            "@fields.field",
+            "has_any_word",
+            ["other"],
+            "Other",
+            "test_destination_3",
+            is_default=True,
+        )
 
         render_output = switch_router.render()
-        self.assertEqual(len(render_output['cases']), 2)
-        self.assertEqual(len(render_output['categories']), 2)
-        self.assertEqual(render_output['categories'][0]['name'], 'Word')
-        self.assertEqual(render_output['categories'][1]['name'], 'Other')
-        self.assertEqual(switch_router.default_category.exit.destination_uuid, 'test_destination_3')
+        self.assertEqual(len(render_output["cases"]), 2)
+        self.assertEqual(len(render_output["categories"]), 2)
+        self.assertEqual(render_output["categories"][0]["name"], "Word")
+        self.assertEqual(render_output["categories"][1]["name"], "Other")
+        self.assertEqual(
+            switch_router.default_category.exit.destination_uuid, "test_destination_3"
+        )
 
     def test_switch_router_blank(self):
-        switch_router = SwitchRouter(operand='@input.text', result_name=None, wait_timeout=600)
-        switch_router.add_choice('@input.text', 'has_any_word', ['word'], '', 'test_destination_1',
-                                      is_default=False)
-        switch_router.update_default_category('test_destination_2')
+        switch_router = SwitchRouter(
+            operand="@input.text", result_name=None, wait_timeout=600
+        )
+        switch_router.add_choice(
+            "@input.text",
+            "has_any_word",
+            ["word"],
+            "",
+            "test_destination_1",
+            is_default=False,
+        )
+        switch_router.update_default_category("test_destination_2")
         # Duplicate case with different destination
-        switch_router.add_choice('@input.text', 'has_any_word', ['word'], '', 'test_destination_3',
-                                      is_default=False)
-        switch_router.update_no_response_category('no_response_destination_uuid')
+        switch_router.add_choice(
+            "@input.text",
+            "has_any_word",
+            ["word"],
+            "",
+            "test_destination_3",
+            is_default=False,
+        )
+        switch_router.update_no_response_category("no_response_destination_uuid")
 
         render_output = switch_router.render()
-        self.assertEqual(len(render_output['cases']), 1)
-        self.assertEqual(len(render_output['categories']), 3)
-        self.assertEqual(render_output['categories'][0]['name'], 'Word')
-        cats = [category for category in switch_router.categories if category.name == 'Word']
+        self.assertEqual(len(render_output["cases"]), 1)
+        self.assertEqual(len(render_output["categories"]), 3)
+        self.assertEqual(render_output["categories"][0]["name"], "Word")
+        cats = [
+            category for category in switch_router.categories if category.name == "Word"
+        ]
         # There should be exactly one Word category, internally
         self.assertEqual(len(cats), 1)
-        self.assertEqual(cats[0].exit.destination_uuid, 'test_destination_3')
+        self.assertEqual(cats[0].exit.destination_uuid, "test_destination_3")
 
 
 class TestNoArgsTests(unittest.TestCase):
-
     def test_no_args_tests(self):
-        switch_router = SwitchRouter(operand='@fields.field')
-        switch_router.add_choice('@fields.field', 'has_text', ['junk'], 'Has Text', 'test_destination_1',
-                                      is_default=False)
+        switch_router = SwitchRouter(operand="@fields.field")
+        switch_router.add_choice(
+            "@fields.field",
+            "has_text",
+            ["junk"],
+            "Has Text",
+            "test_destination_1",
+            is_default=False,
+        )
 
         render_output = switch_router.render()
-        self.assertEqual(len(render_output['cases']), 1)
-        self.assertEqual(len(render_output['categories']), 2)
-        self.assertEqual(render_output['cases'][0]['arguments'], [])
-        self.assertEqual(render_output['categories'][0]['name'], 'Has Text')
-        self.assertEqual(render_output['categories'][1]['name'], 'Other')
+        self.assertEqual(len(render_output["cases"]), 1)
+        self.assertEqual(len(render_output["categories"]), 2)
+        self.assertEqual(render_output["cases"][0]["arguments"], [])
+        self.assertEqual(render_output["categories"][0]["name"], "Has Text")
+        self.assertEqual(render_output["categories"][1]["name"], "Other")
         self.assertEqual(switch_router.default_category.exit.destination_uuid, None)
-        self.assertEqual(switch_router.categories[0].exit.destination_uuid, 'test_destination_1')
+        self.assertEqual(
+            switch_router.categories[0].exit.destination_uuid, "test_destination_1"
+        )
 
     def test_invalid_test(self):
-        switch_router = SwitchRouter(operand='@fields.field')
+        switch_router = SwitchRouter(operand="@fields.field")
         with self.assertRaises(ValueError):
-            switch_router.add_choice('@fields.field', 'has_junk', ['junk'], 'Has Just', 'test_destination_1',
-                                          is_default=False)
+            switch_router.add_choice(
+                "@fields.field",
+                "has_junk",
+                ["junk"],
+                "Has Just",
+                "test_destination_1",
+                is_default=False,
+            )

--- a/tests/test_rowdatasheet.py
+++ b/tests/test_rowdatasheet.py
@@ -9,62 +9,70 @@ from rpft.parsers.common.rowdatasheet import RowDataSheet
 from tests.mocks import MockRowParser
 
 
-rowA = OrderedDict([
-    ('str_field', 'main string A'),
-    ('list_str:0', 'a'),
-    ('list_str:1', 'b'),
-    ('model_default:int_field', 5),
-])
+rowA = OrderedDict(
+    [
+        ("str_field", "main string A"),
+        ("list_str:0", "a"),
+        ("list_str:1", "b"),
+        ("model_default:int_field", 5),
+    ]
+)
 
-rowB = OrderedDict([
-    ('str_field', 'main string B'),
-    ('2nd_field', '2nd field'),
-    ('list_str:0', 'A'),
-])
+rowB = OrderedDict(
+    [
+        ("str_field", "main string B"),
+        ("2nd_field", "2nd field"),
+        ("list_str:0", "A"),
+    ]
+)
 
-rowC = OrderedDict([
-    ('model_default:int_field', 15),
-    ('x:y:z', 'x y z'),
-])
+rowC = OrderedDict(
+    [
+        ("model_default:int_field", 15),
+        ("x:y:z", "x y z"),
+    ]
+)
 
 rowD = OrderedDict()
 
-rowCycle = OrderedDict([
-    ('list_str:0', '1'),
-    ('str_field', 'main string Cycle'),
-])
+rowCycle = OrderedDict(
+    [
+        ("list_str:0", "1"),
+        ("str_field", "main string Cycle"),
+    ]
+)
 
 headersABCD_exp = [
-    'str_field',
-    '2nd_field',
-    'list_str:0',
-    'list_str:1',
-    'model_default:int_field',
-    'x:y:z',
+    "str_field",
+    "2nd_field",
+    "list_str:0",
+    "list_str:1",
+    "model_default:int_field",
+    "x:y:z",
 ]
 
 contentABCD_exp = [
-    ('main string A', '', 'a', 'b', 5, ''),
-    ('main string B', '2nd field', 'A', '', '', ''),
-    ('', '', '', '', 15, 'x y z'),
-    ('', '', '', '', '', ''),
+    ("main string A", "", "a", "b", 5, ""),
+    ("main string B", "2nd field", "A", "", "", ""),
+    ("", "", "", "", 15, "x y z"),
+    ("", "", "", "", "", ""),
 ]
 
 headersAC_exp = [
-    'str_field',
-    'list_str:0',
-    'list_str:1',
-    'model_default:int_field',
-    'x:y:z',
+    "str_field",
+    "list_str:0",
+    "list_str:1",
+    "model_default:int_field",
+    "x:y:z",
 ]
 
 contentAC_exp = [
-    ('main string A', 'a', 'b', 5, ''),
-    ('', '', '', 15, 'x y z'),
+    ("main string A", "a", "b", 5, ""),
+    ("", "", "", 15, "x y z"),
 ]
 
-class TestRowDataSheet(unittest.TestCase):
 
+class TestRowDataSheet(unittest.TestCase):
     def setUp(self):
         self.rowparser = MockRowParser()
 
@@ -101,19 +109,17 @@ class TestRowDataSheet(unittest.TestCase):
         # but we want to make sure here the export function works.
         with TemporaryDirectory() as outdir:
             outfile = Path(outdir) / "export.csv"
-            RowDataSheet(
-                self.rowparser, [rowA, rowC]
-            ).export(outfile)
+            RowDataSheet(self.rowparser, [rowA, rowC]).export(outfile)
 
     def test_export_xlsx(self):
         # Not our job to test the contents (tablib's responsibility),
         # but we want to make sure here the export function works.
         with TemporaryDirectory() as outdir:
             outfile = Path(outdir) / "export.xlsx"
-            RowDataSheet(
-                self.rowparser, [rowA, rowC]
-            ).export(outfile, file_format='xlsx')
+            RowDataSheet(self.rowparser, [rowA, rowC]).export(
+                outfile, file_format="xlsx"
+            )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sheetparser.py
+++ b/tests/test_sheetparser.py
@@ -11,45 +11,53 @@ from tests.mocks import MockRowParser
 
 
 class MainModel(ParserModel):
-    field1: str = ''
-    field2: str = ''
+    field1: str = ""
+    field2: str = ""
 
 
-input1 = '''field1,field2
+input1 = """field1,field2
 row1f1,row1f2
 row2f1,row2f2
 row3f1,row3f2
-'''
+"""
+
 
 class TestSheetParser(unittest.TestCase):
-
     def setUp(self):
         self.rowparser = MockRowParser()
-        self.table1 = tablib.import_set(input1, format='csv')
+        self.table1 = tablib.import_set(input1, format="csv")
 
     def test_context_and_bookmarks(self):
         parser = SheetParser(self.rowparser, self.table1)
         row1 = parser.parse_next_row()
-        self.assertEqual(row1, {'field1' : 'row1f1', 'field2' : 'row1f2', 'context' : {}})
-        parser.create_bookmark('row2')
-        parser.add_to_context('key', 'value')
+        self.assertEqual(row1, {"field1": "row1f1", "field2": "row1f2", "context": {}})
+        parser.create_bookmark("row2")
+        parser.add_to_context("key", "value")
         row2 = parser.parse_next_row()
-        self.assertEqual(row2, {'field1' : 'row2f1', 'field2' : 'row2f2', 'context' : {'key': 'value'}})
-        parser.remove_from_context('key')
+        self.assertEqual(
+            row2, {"field1": "row2f1", "field2": "row2f2", "context": {"key": "value"}}
+        )
+        parser.remove_from_context("key")
         row3 = parser.parse_next_row()
-        self.assertEqual(row3, {'field1' : 'row3f1', 'field2' : 'row3f2', 'context' : {}})
-        parser.go_to_bookmark('row2')
+        self.assertEqual(row3, {"field1": "row3f1", "field2": "row3f2", "context": {}})
+        parser.go_to_bookmark("row2")
         row2b = parser.parse_next_row()
-        self.assertEqual(row2b, {'field1' : 'row2f1', 'field2' : 'row2f2', 'context' : {}})
+        self.assertEqual(row2b, {"field1": "row2f1", "field2": "row2f2", "context": {}})
 
     def test_parse_all(self):
         parser = SheetParser(self.rowparser, self.table1)
         rows = parser.parse_all()
-        self.assertEqual(len(rows), 3)        
-        self.assertEqual(rows[0], {'field1' : 'row1f1', 'field2' : 'row1f2', 'context' : {}})        
-        self.assertEqual(rows[1], {'field1' : 'row2f1', 'field2' : 'row2f2', 'context' : {}})        
-        self.assertEqual(rows[2], {'field1' : 'row3f1', 'field2' : 'row3f2', 'context' : {}})        
+        self.assertEqual(len(rows), 3)
+        self.assertEqual(
+            rows[0], {"field1": "row1f1", "field2": "row1f2", "context": {}}
+        )
+        self.assertEqual(
+            rows[1], {"field1": "row2f1", "field2": "row2f2", "context": {}}
+        )
+        self.assertEqual(
+            rows[2], {"field1": "row3f1", "field2": "row3f2", "context": {}}
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tagmatcher.py
+++ b/tests/test_tagmatcher.py
@@ -3,7 +3,6 @@ from rpft.parsers.creation.tagmatcher import TagMatcher
 
 
 class TestTagMatcher(unittest.TestCase):
-
     def test_empty_matcher(self):
         tm = TagMatcher()
         self.assertTrue(tm.matches([]))

--- a/tests/test_template_sheet_parser.py
+++ b/tests/test_template_sheet_parser.py
@@ -11,6 +11,7 @@ class ResponseMessages(ParserModel):
     positive: str
     negative: str
 
+
 class YesNoTemplate(ParserModel):
     ID: str
     prompt: str
@@ -18,43 +19,46 @@ class YesNoTemplate(ParserModel):
 
 
 class TestParsing(unittest.TestCase):
-
     def setUp(self) -> None:
         row_parser = RowParser(YesNoTemplate, CellParser())
         self.template_sheet_parser = TemplateSheetParser(row_parser)
 
     def test_parse(self):
-        flow_rows = get_table_from_file('input/templates/yes_no_template.csv')
-        template_rows = get_table_from_file('input/templates/yes_no_template_instances.csv')
-        rapidpro_container = self.template_sheet_parser.parse_sheet(template_rows, flow_rows)
+        flow_rows = get_table_from_file("input/templates/yes_no_template.csv")
+        template_rows = get_table_from_file(
+            "input/templates/yes_no_template_instances.csv"
+        )
+        rapidpro_container = self.template_sheet_parser.parse_sheet(
+            template_rows, flow_rows
+        )
 
         self.assertEqual(len(rapidpro_container.flows), 2)
 
         flow0 = rapidpro_container.flows[0].render()
         flow1 = rapidpro_container.flows[1].render()
 
-        context = Context(inputs=['yes'])
+        context = Context(inputs=["yes"])
         actions0 = traverse_flow(flow0, copy.deepcopy(context))
         actions1 = traverse_flow(flow1, copy.deepcopy(context))
-        actions_exp0 = [('send_msg', 'Are you happy?'), ('send_msg', 'Amaaaazing!')]
-        actions_exp1 = [('send_msg', 'Are you sad?'), ('send_msg', 'Oh no!')]
+        actions_exp0 = [("send_msg", "Are you happy?"), ("send_msg", "Amaaaazing!")]
+        actions_exp1 = [("send_msg", "Are you sad?"), ("send_msg", "Oh no!")]
         self.assertEqual(actions0, actions_exp0)
         self.assertEqual(actions1, actions_exp1)
 
-        context = Context(inputs=['something', 'no'])
+        context = Context(inputs=["something", "no"])
         actions0 = traverse_flow(flow0, copy.deepcopy(context))
         actions1 = traverse_flow(flow1, copy.deepcopy(context))
         actions_exp0 = [
-            ('send_msg', 'Are you happy?'), 
-            ('send_msg', "Sorry, I don't understand what you mean."), 
-            ('send_msg', 'Are you happy?'), 
-            ('send_msg', 'Oh no!')
+            ("send_msg", "Are you happy?"),
+            ("send_msg", "Sorry, I don't understand what you mean."),
+            ("send_msg", "Are you happy?"),
+            ("send_msg", "Oh no!"),
         ]
         actions_exp1 = [
-            ('send_msg', 'Are you sad?'), 
-            ('send_msg', "Sorry, I don't understand what you mean."), 
-            ('send_msg', 'Are you sad?'), 
-            ('send_msg', 'Good to hear.')
+            ("send_msg", "Are you sad?"),
+            ("send_msg", "Sorry, I don't understand what you mean."),
+            ("send_msg", "Are you sad?"),
+            ("send_msg", "Good to hear."),
         ]
         self.assertEqual(actions0, actions_exp0)
         self.assertEqual(actions1, actions_exp1)

--- a/tests/test_to_row_model.py
+++ b/tests/test_to_row_model.py
@@ -3,35 +3,46 @@ import unittest
 from rpft.parsers.common.rowdatasheet import RowDataSheet
 from rpft.parsers.common.rowparser import RowParser
 from rpft.rapidpro.models.containers import FlowContainer
-from rpft.rapidpro.models.actions import Group, SendMessageAction, AddContactGroupAction, SetRunResultAction, SetContactFieldAction
-from rpft.rapidpro.models.nodes import BasicNode, SwitchRouterNode, RandomRouterNode, EnterFlowNode
+from rpft.rapidpro.models.actions import (
+    Group,
+    SendMessageAction,
+    AddContactGroupAction,
+    SetRunResultAction,
+    SetContactFieldAction,
+)
+from rpft.rapidpro.models.nodes import (
+    BasicNode,
+    SwitchRouterNode,
+    RandomRouterNode,
+    EnterFlowNode,
+)
 from rpft.parsers.creation.flowrowmodel import FlowRowModel, Edge
 from tests.row_data import get_start_row, get_unconditional_node_from_1
 
 
 class TestToRowModels(unittest.TestCase):
-
     def compare_row_models_without_uuid(self, row_models1, row_models2):
         self.maxDiff = None
         self.assertEqual(len(row_models1), len(row_models2))
         for model1, model2 in zip(row_models1, row_models2):
             data1 = model1.dict()
             data2 = model2.dict()
-            if not data1['node_uuid'] or not data2['node_uuid']:
+            if not data1["node_uuid"] or not data2["node_uuid"]:
                 # If one of them is blank, skip the comparison
-                data1.pop('node_uuid')
-                data2.pop('node_uuid')
+                data1.pop("node_uuid")
+                data2.pop("node_uuid")
             self.assertEqual(data1, data2)
 
 
 class TestNodes(TestToRowModels):
-
     def test_basic_node(self):
         row_data = get_start_row()
         node = BasicNode()
-        action = SendMessageAction(row_data.mainarg_message_text, quick_replies=row_data.choices)
+        action = SendMessageAction(
+            row_data.mainarg_message_text, quick_replies=row_data.choices
+        )
         node.add_action(action)
-        node.initiate_row_models(1, Edge(from_='start'))
+        node.initiate_row_models(1, Edge(from_="start"))
         row_models = node.get_row_models()
         self.compare_row_models_without_uuid(row_models, [row_data])
 
@@ -39,43 +50,54 @@ class TestNodes(TestToRowModels):
         row_data1 = get_start_row()
         row_data2 = get_unconditional_node_from_1()
         node = BasicNode()
-        action = SendMessageAction(row_data1.mainarg_message_text, quick_replies=row_data1.choices)
+        action = SendMessageAction(
+            row_data1.mainarg_message_text, quick_replies=row_data1.choices
+        )
         node.add_action(action)
-        action = SendMessageAction(row_data2.mainarg_message_text, quick_replies=row_data2.choices)
+        action = SendMessageAction(
+            row_data2.mainarg_message_text, quick_replies=row_data2.choices
+        )
         node.add_action(action)
-        node.initiate_row_models('1', Edge(from_='start'))
+        node.initiate_row_models("1", Edge(from_="start"))
         row_models = node.get_row_models()
         # The section action gets row ID 1.1, which needs to be remapped to 2.
         # When converting flows to rows, this remapping is done automatically.
-        row_models[1].row_id = '2'
+        row_models[1].row_id = "2"
         self.compare_row_models_without_uuid(row_models, [row_data1, row_data2])
 
     def test_add_group_node(self):
-        row_data = FlowRowModel(**{
-            'row_id' : '1',
-            'type' : 'add_to_group',
-            'mainarg_groups' : ['test group'],
-            'obj_id' : '8224bfe2-acec-434f-bc7c-14c584fc4bc8',
-            'edges' : [{ 'from_': 'start' }],
-            'ui_position' : ['123','456'],
-            'node_uuid' : '224f6caa-fd25-47d3-96a9-3d43506b7878',
-        })
-        node = BasicNode(uuid=row_data.node_uuid, ui_pos=(int(p) for p in row_data.ui_position))
-        action = AddContactGroupAction([Group(row_data.mainarg_groups[0], row_data.obj_id)])
+        row_data = FlowRowModel(
+            **{
+                "row_id": "1",
+                "type": "add_to_group",
+                "mainarg_groups": ["test group"],
+                "obj_id": "8224bfe2-acec-434f-bc7c-14c584fc4bc8",
+                "edges": [{"from_": "start"}],
+                "ui_position": ["123", "456"],
+                "node_uuid": "224f6caa-fd25-47d3-96a9-3d43506b7878",
+            }
+        )
+        node = BasicNode(
+            uuid=row_data.node_uuid, ui_pos=(int(p) for p in row_data.ui_position)
+        )
+        action = AddContactGroupAction(
+            [Group(row_data.mainarg_groups[0], row_data.obj_id)]
+        )
         node.add_action(action)
-        node.initiate_row_models(1, Edge(from_='start'))
+        node.initiate_row_models(1, Edge(from_="start"))
         row_models = node.get_row_models()
         self.compare_row_models_without_uuid(row_models, [row_data])
 
 
 class TestFlowContainer(TestToRowModels):
-
     def test_basic_node(self):
         row_data = get_start_row()
         node = BasicNode()
-        action = SendMessageAction(row_data.mainarg_message_text, quick_replies=row_data.choices)
+        action = SendMessageAction(
+            row_data.mainarg_message_text, quick_replies=row_data.choices
+        )
         node.add_action(action)
-        container = FlowContainer('test_flow')
+        container = FlowContainer("test_flow")
         container.add_node(node)
         row_models = container.to_rows()
         self.compare_row_models_without_uuid(row_models, [row_data])
@@ -85,37 +107,50 @@ class TestFlowContainer(TestToRowModels):
         row_data2 = get_unconditional_node_from_1()
         node1 = BasicNode()
         node2 = BasicNode()
-        action1 = SendMessageAction(row_data1.mainarg_message_text, quick_replies=row_data1.choices)
-        action2 = SendMessageAction(row_data2.mainarg_message_text, quick_replies=row_data2.choices)
+        action1 = SendMessageAction(
+            row_data1.mainarg_message_text, quick_replies=row_data1.choices
+        )
+        action2 = SendMessageAction(
+            row_data2.mainarg_message_text, quick_replies=row_data2.choices
+        )
         node1.add_action(action1)
         node2.add_action(action2)
         node1.update_default_exit(node2.uuid)
-        container = FlowContainer('test_flow')
+        container = FlowContainer("test_flow")
         container.add_node(node1)
         container.add_node(node2)
         row_models = container.to_rows()
         self.compare_row_models_without_uuid(row_models, [row_data1, row_data2])
 
     def test_conditional_edge(self):
-        row_data1 = FlowRowModel(**{
-            'row_id' : '1',
-            'type' : 'split_by_value',
-            'edges' : [{ 'from_': 'start' }],
-            'mainarg_expression' : '@fields.name',
-        })
-        row_data2 = FlowRowModel(**{
-            'row_id' : '2',
-            'type' : 'send_message',
-            'edges' : [
-                {
-                    'from_': '1',
-                    'condition': {'value':'3', 'variable':'@fields.name', 'type':'has_phrase', 'name':'3'},
-                }
-            ],
-            'mainarg_message_text' : 'Message if @fields.name == 3',
-        })
+        row_data1 = FlowRowModel(
+            **{
+                "row_id": "1",
+                "type": "split_by_value",
+                "edges": [{"from_": "start"}],
+                "mainarg_expression": "@fields.name",
+            }
+        )
+        row_data2 = FlowRowModel(
+            **{
+                "row_id": "2",
+                "type": "send_message",
+                "edges": [
+                    {
+                        "from_": "1",
+                        "condition": {
+                            "value": "3",
+                            "variable": "@fields.name",
+                            "type": "has_phrase",
+                            "name": "3",
+                        },
+                    }
+                ],
+                "mainarg_message_text": "Message if @fields.name == 3",
+            }
+        )
         case = row_data2.edges[0].condition
-        container = FlowContainer('test_flow')
+        container = FlowContainer("test_flow")
 
         node1 = SwitchRouterNode(case.variable)
         node2 = BasicNode()
@@ -123,7 +158,9 @@ class TestFlowContainer(TestToRowModels):
         node1.add_choice(case.variable, case.type, [case.value], case.name, node2.uuid)
         container.add_node(node1)
 
-        action2 = SendMessageAction(row_data2.mainarg_message_text, quick_replies=row_data2.choices)
+        action2 = SendMessageAction(
+            row_data2.mainarg_message_text, quick_replies=row_data2.choices
+        )
         node2.add_action(action2)
         container.add_node(node2)
 
@@ -131,33 +168,43 @@ class TestFlowContainer(TestToRowModels):
         self.compare_row_models_without_uuid(row_models, [row_data1, row_data2])
 
     def test_conditional_edge2(self):
-        row_data1 = FlowRowModel(**{
-            'row_id' : '1',
-            'type' : 'split_by_group',
-            'edges' : [{ 'from_': 'start' }],
-            'mainarg_groups' : ['my group'],
-            'obj_id' : '12345678'
-        })
-        row_data2 = FlowRowModel(**{
-            'row_id' : '2',
-            'type' : 'save_value',
-            'edges' : [
-                {
-                    'from_': '1',
-                    'condition': {'value':'my group'},
-                }
-            ],
-            'mainarg_value' : 'my value',
-            'save_name' : 'my variable',
-        })
+        row_data1 = FlowRowModel(
+            **{
+                "row_id": "1",
+                "type": "split_by_group",
+                "edges": [{"from_": "start"}],
+                "mainarg_groups": ["my group"],
+                "obj_id": "12345678",
+            }
+        )
+        row_data2 = FlowRowModel(
+            **{
+                "row_id": "2",
+                "type": "save_value",
+                "edges": [
+                    {
+                        "from_": "1",
+                        "condition": {"value": "my group"},
+                    }
+                ],
+                "mainarg_value": "my value",
+                "save_name": "my variable",
+            }
+        )
         case = row_data2.edges[0].condition
-        container = FlowContainer('test_flow')
+        container = FlowContainer("test_flow")
 
-        node1 = SwitchRouterNode('@contact.groups')
+        node1 = SwitchRouterNode("@contact.groups")
         node2 = BasicNode()
 
         # The arguments for this choice is [group uuid, group name]
-        node1.add_choice(case.variable, case.type or 'has_group', [row_data1.obj_id, case.value], case.name, node2.uuid)
+        node1.add_choice(
+            case.variable,
+            case.type or "has_group",
+            [row_data1.obj_id, case.value],
+            case.name,
+            node2.uuid,
+        )
         container.add_node(node1)
 
         action2 = SetContactFieldAction(row_data2.save_name, row_data2.mainarg_value)
@@ -171,25 +218,35 @@ class TestFlowContainer(TestToRowModels):
         # Two edges into the same node (i.e. forward edge in the tree)
         # Uses random router
 
-        row_data1 = FlowRowModel(**{
-            'row_id' : '1',
-            'type' : 'split_random',
-            'edges' : [{ 'from_': 'start' }],
-        })
+        row_data1 = FlowRowModel(
+            **{
+                "row_id": "1",
+                "type": "split_random",
+                "edges": [{"from_": "start"}],
+            }
+        )
 
-        row_data2 = FlowRowModel(**{
-            'row_id' : '2',
-            'type' : 'send_message',
-            'edges' : [
-                { 'from_': '1', 'condition': {'value':'1'}, },
-                { 'from_': '1', 'condition': {'value':'2'}, }
-            ],
-            'mainarg_message_text' : 'Second node message',
-        })
+        row_data2 = FlowRowModel(
+            **{
+                "row_id": "2",
+                "type": "send_message",
+                "edges": [
+                    {
+                        "from_": "1",
+                        "condition": {"value": "1"},
+                    },
+                    {
+                        "from_": "1",
+                        "condition": {"value": "2"},
+                    },
+                ],
+                "mainarg_message_text": "Second node message",
+            }
+        )
 
         case1 = row_data2.edges[0].condition
         case2 = row_data2.edges[1].condition
-        container = FlowContainer('test_flow')
+        container = FlowContainer("test_flow")
 
         node1 = RandomRouterNode()
         node2 = BasicNode()
@@ -208,53 +265,76 @@ class TestFlowContainer(TestToRowModels):
     def test_cyclic_wait_edge(self):
         # An edge for a wait_for_response node to itself (cycle) via go_to
 
-        row_data1 = FlowRowModel(**{
-            'row_id' : '1',
-            'type' : 'wait_for_response',
-            'save_name' : 'wait_result',
-            'no_response' : '300',
-            'edges' : [{ 'from_': 'start' }],
-        })
+        row_data1 = FlowRowModel(
+            **{
+                "row_id": "1",
+                "type": "wait_for_response",
+                "save_name": "wait_result",
+                "no_response": "300",
+                "edges": [{"from_": "start"}],
+            }
+        )
         # A proper case
-        row_data2 = FlowRowModel(**{
-            'row_id' : '2',
-            'type' : 'go_to',
-            'edges' : [
-                {
-                    'from_': '1',
-                    'condition': {'value':'word', 'variable':'@input.text', 'type':'has_any_word', 'name':'Word'},
-                }
-            ],
-            'mainarg_destination_row_ids' : ['1'],
-        })
+        row_data2 = FlowRowModel(
+            **{
+                "row_id": "2",
+                "type": "go_to",
+                "edges": [
+                    {
+                        "from_": "1",
+                        "condition": {
+                            "value": "word",
+                            "variable": "@input.text",
+                            "type": "has_any_word",
+                            "name": "Word",
+                        },
+                    }
+                ],
+                "mainarg_destination_row_ids": ["1"],
+            }
+        )
         # The 'Other' category
-        row_data3 = FlowRowModel(**{
-            'row_id' : '3',
-            'type' : 'send_message',
-            'edges' : [{ 'from_': '1', }],
-            'mainarg_message_text' : 'Second node message',
-        })
+        row_data3 = FlowRowModel(
+            **{
+                "row_id": "3",
+                "type": "send_message",
+                "edges": [
+                    {
+                        "from_": "1",
+                    }
+                ],
+                "mainarg_message_text": "Second node message",
+            }
+        )
         # The no response category
-        row_data4 = FlowRowModel(**{
-            'row_id' : '4',
-            'type' : 'send_message',
-            'edges' : [
-                {
-                    'from_': '1',
-                    'condition': {'value':'No Response'},
-                }
-            ],
-            'mainarg_message_text' : 'Third node message',
-        })
+        row_data4 = FlowRowModel(
+            **{
+                "row_id": "4",
+                "type": "send_message",
+                "edges": [
+                    {
+                        "from_": "1",
+                        "condition": {"value": "No Response"},
+                    }
+                ],
+                "mainarg_message_text": "Third node message",
+            }
+        )
 
         case1 = row_data2.edges[0].condition
         case2 = row_data3.edges[0].condition
         case3 = row_data4.edges[0].condition
-        container = FlowContainer('test_flow')
-        node1 = SwitchRouterNode('@input.text', result_name=row_data1.save_name, wait_timeout=int(row_data1.no_response))
+        container = FlowContainer("test_flow")
+        node1 = SwitchRouterNode(
+            "@input.text",
+            result_name=row_data1.save_name,
+            wait_timeout=int(row_data1.no_response),
+        )
         node2 = BasicNode()
         node3 = BasicNode()
-        node1.add_choice(case1.variable, case1.type, [case1.value], case1.name, node1.uuid)
+        node1.add_choice(
+            case1.variable, case1.type, [case1.value], case1.name, node1.uuid
+        )
         node1.update_default_exit(node2.uuid)
         node1.update_no_response_exit(node3.uuid)
         container.add_node(node1)
@@ -267,40 +347,53 @@ class TestFlowContainer(TestToRowModels):
         container.add_node(node3)
 
         row_models = container.to_rows()
-        self.compare_row_models_without_uuid(row_models, [row_data1, row_data2, row_data3, row_data4])
+        self.compare_row_models_without_uuid(
+            row_models, [row_data1, row_data2, row_data3, row_data4]
+        )
 
     def test_enter_flow_edge(self):
         # Test expired (default) edge of enter_flow node
         # test save_flow_result with a @result (set_run_result in rapidpro)
 
-        row_data1 = FlowRowModel(**{
-            'row_id' : '1',
-            'type' : 'start_new_flow',
-            'mainarg_flow_name' : 'sample_flow',
-            'obj_id' : '8224bfe2-acec-434f-bc7c-14c584fc4bc8',
-            'edges' : [{ 'from_': 'start' }],
-        })
+        row_data1 = FlowRowModel(
+            **{
+                "row_id": "1",
+                "type": "start_new_flow",
+                "mainarg_flow_name": "sample_flow",
+                "obj_id": "8224bfe2-acec-434f-bc7c-14c584fc4bc8",
+                "edges": [{"from_": "start"}],
+            }
+        )
 
-        row_data2 = FlowRowModel(**{
-            'row_id' : '2',
-            'type' : 'save_flow_result',
-            'edges' : [
-                {
-                    'from_': '1',
-                    'condition': {'value':'expired'},
-                    # 'variable':'@child.run.status', 'type':'has_only_text', 'name':'Expired' are implicit
-                }
-            ],
-            'mainarg_value' : 'Value',
-            'save_name' : 'my result',
-        })
+        row_data2 = FlowRowModel(
+            **{
+                "row_id": "2",
+                "type": "save_flow_result",
+                "edges": [
+                    {
+                        "from_": "1",
+                        "condition": {"value": "expired"},
+                        # 'variable':'@child.run.status', 'type':'has_only_text', 'name':'Expired' are implicit
+                    }
+                ],
+                "mainarg_value": "Value",
+                "save_name": "my result",
+            }
+        )
 
         case1 = row_data2.edges[0].condition
-        container = FlowContainer('test_flow')
+        container = FlowContainer("test_flow")
 
         node1 = EnterFlowNode(row_data1.mainarg_flow_name, row_data1.obj_id)
         node2 = BasicNode()
-        node1.add_choice(case1.variable, case1.type or 'has_only_text', [case1.value], case1.name, node2.uuid, is_default=True)
+        node1.add_choice(
+            case1.variable,
+            case1.type or "has_only_text",
+            [case1.value],
+            case1.name,
+            node2.uuid,
+            is_default=True,
+        )
         container.add_node(node1)
 
         action2 = SetRunResultAction(row_data2.save_name, row_data2.mainarg_value)
@@ -313,80 +406,82 @@ class TestFlowContainer(TestToRowModels):
 
 class TestRowModelExport(unittest.TestCase):
     def test_row_model_export(self):
-        row_data = FlowRowModel(**{
-            'row_id' : '1',
-            'type' : 'send_message',
-            'mainarg_message_text' : 'Hello',
-            'choices' : ['QR1', 'QR2', 'QR3'],
-            'edges' : [{ 'from_': 'start' }],
-            'node_uuid' : '224f6caa-fd25-47d3-96a9-3d43506b7878',
-            'ui_position' : ['123','456'],
-        })
+        row_data = FlowRowModel(
+            **{
+                "row_id": "1",
+                "type": "send_message",
+                "mainarg_message_text": "Hello",
+                "choices": ["QR1", "QR2", "QR3"],
+                "edges": [{"from_": "start"}],
+                "node_uuid": "224f6caa-fd25-47d3-96a9-3d43506b7878",
+                "ui_position": ["123", "456"],
+            }
+        )
 
         # Because default values are '', even blank fields are exported.
         # This may change in the future.
         expected_headers = [
-            'row_id',
-            'type',
-            'edges.1.from',
-            'edges.1.condition.value',
-            'edges.1.condition.variable',
-            'edges.1.condition.type',
-            'edges.1.condition.name',
+            "row_id",
+            "type",
+            "edges.1.from",
+            "edges.1.condition.value",
+            "edges.1.condition.variable",
+            "edges.1.condition.type",
+            "edges.1.condition.name",
             # 'loop_variable',
-            'include_if',
-            'message_text',
-            'wa_template.name',
-            'wa_template.uuid',
-            'data_sheet',
-            'data_row_id',
-            'choices.1',
-            'choices.2',
-            'choices.3',
-            'save_name',
-            'result_category',
-            'image',
-            'audio',
-            'video',
-            'obj_name',
-            'obj_id',
-            'node_name',
-            '_nodeId',
-            'no_response',
-            '_ui_type',
-            '_ui_position.1',
-            '_ui_position.2',
+            "include_if",
+            "message_text",
+            "wa_template.name",
+            "wa_template.uuid",
+            "data_sheet",
+            "data_row_id",
+            "choices.1",
+            "choices.2",
+            "choices.3",
+            "save_name",
+            "result_category",
+            "image",
+            "audio",
+            "video",
+            "obj_name",
+            "obj_id",
+            "node_name",
+            "_nodeId",
+            "no_response",
+            "_ui_type",
+            "_ui_position.1",
+            "_ui_position.2",
         ]
         expected_content = (
-            '1', 
-            'send_message', 
-            'start', 
-            '', 
-            '', 
-            '', 
-            '', 
-            True, 
-            '', 
-            '', 
-            '', 
-            '', 
-            '', 
-            'QR1', 
-            'QR2', 
-            'QR3', 
-            '', 
-            '', 
-            '', 
-            '', 
-            '', 
-            '', 
-            '', 
-            '', 
-            '224f6caa-fd25-47d3-96a9-3d43506b7878', 
-            '', 
-            '', 
-            '123', 
-            '456',
+            "1",
+            "send_message",
+            "start",
+            "",
+            "",
+            "",
+            "",
+            True,
+            "",
+            "",
+            "",
+            "",
+            "",
+            "QR1",
+            "QR2",
+            "QR3",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "",
+            "224f6caa-fd25-47d3-96a9-3d43506b7878",
+            "",
+            "",
+            "123",
+            "456",
         )
 
         sheet = RowDataSheet(RowParser(FlowRowModel, None), [row_data])

--- a/tests/test_unparse.py
+++ b/tests/test_unparse.py
@@ -10,11 +10,11 @@ from tests.mocks import MockCellParser
 class ModelWithStuff(ParserModel):
     list_str: List[str] = []
     int_field: int = 0
-    str_field: str = ''
+    str_field: str = ""
 
 
 class MainModel(ParserModel):
-    str_field: str = ''
+    str_field: str = ""
     model_optional: Optional[ModelWithStuff]
     model_default: ModelWithStuff = ModelWithStuff()
     model_list: List[ModelWithStuff] = []
@@ -22,131 +22,144 @@ class MainModel(ParserModel):
 
 input1 = MainModel()
 
-output1_exp = OrderedDict([
-    ('str_field', ''),
-    ('model_default.int_field', 0),
-    ('model_default.str_field', ''),
-])
+output1_exp = OrderedDict(
+    [
+        ("str_field", ""),
+        ("model_default.int_field", 0),
+        ("model_default.str_field", ""),
+    ]
+)
 
-input2 = MainModel(**{
-    'str_field' : 'main model string',
-    'model_default' : {
-        'list_str' : ['a', 'b', 'c'],
-        'int_field' : 5,
-        'str_field' : 'string'
-    }
-})
-
-output2_exp = OrderedDict([
-    ('str_field', 'main model string'),
-    ('model_default.list_str.1', 'a'),
-    ('model_default.list_str.2', 'b'),
-    ('model_default.list_str.3', 'c'),
-    ('model_default.int_field', 5),
-    ('model_default.str_field', 'string'),
-])
-
-input3 = MainModel(**{
-    'str_field' : 'main model string',
-    'model_default' : {
-        'list_str' : [],
-        'int_field' : 15,
-        'str_field' : ''
-    }
-})
-
-output3_exp = OrderedDict([
-    ('str_field', 'main model string'),
-    ('model_default.int_field', 15),
-    ('model_default.str_field', ''),
-])
-
-input4 = MainModel(**{
-    'str_field' : 'main model string',
-    'model_default' : {
-        'list_str' : ['a', 'b'],
-        'int_field' : 5,
-        'str_field' : 'default'
-    },
-    'model_optional' : {
-        'list_str' : ['c', 'd'],
-        'int_field' : 10,
-        'str_field' : 'optional'
-    },
-    'model_list' : [
-        {
-            'list_str' : ['A', 'B', 'C'],
-            'str_field' : 'string from first model in list'
+input2 = MainModel(
+    **{
+        "str_field": "main model string",
+        "model_default": {
+            "list_str": ["a", "b", "c"],
+            "int_field": 5,
+            "str_field": "string",
         },
-        {
-            'int_field' : 15,
-        },
-    ],
-})
+    }
+)
 
-output4_exp = OrderedDict([
-    ('str_field', 'main model string'),
-    ('model_optional.list_str.1', 'c'),
-    ('model_optional.list_str.2', 'd'),
-    ('model_optional.int_field', 10),
-    ('model_optional.str_field', 'optional'),
-    ('model_default.list_str.1', 'a'),
-    ('model_default.list_str.2', 'b'),
-    ('model_default.int_field', 5),
-    ('model_default.str_field', 'default'),
-    ('model_list.1.list_str.1', 'A'),
-    ('model_list.1.list_str.2', 'B'),
-    ('model_list.1.list_str.3', 'C'),
-    ('model_list.1.int_field', 0),
-    ('model_list.1.str_field', 'string from first model in list'),
-    ('model_list.2.int_field', 15),
-    ('model_list.2.str_field', ''),
-])
+output2_exp = OrderedDict(
+    [
+        ("str_field", "main model string"),
+        ("model_default.list_str.1", "a"),
+        ("model_default.list_str.2", "b"),
+        ("model_default.list_str.3", "c"),
+        ("model_default.int_field", 5),
+        ("model_default.str_field", "string"),
+    ]
+)
+
+input3 = MainModel(
+    **{
+        "str_field": "main model string",
+        "model_default": {"list_str": [], "int_field": 15, "str_field": ""},
+    }
+)
+
+output3_exp = OrderedDict(
+    [
+        ("str_field", "main model string"),
+        ("model_default.int_field", 15),
+        ("model_default.str_field", ""),
+    ]
+)
+
+input4 = MainModel(
+    **{
+        "str_field": "main model string",
+        "model_default": {
+            "list_str": ["a", "b"],
+            "int_field": 5,
+            "str_field": "default",
+        },
+        "model_optional": {
+            "list_str": ["c", "d"],
+            "int_field": 10,
+            "str_field": "optional",
+        },
+        "model_list": [
+            {
+                "list_str": ["A", "B", "C"],
+                "str_field": "string from first model in list",
+            },
+            {
+                "int_field": 15,
+            },
+        ],
+    }
+)
+
+output4_exp = OrderedDict(
+    [
+        ("str_field", "main model string"),
+        ("model_optional.list_str.1", "c"),
+        ("model_optional.list_str.2", "d"),
+        ("model_optional.int_field", 10),
+        ("model_optional.str_field", "optional"),
+        ("model_default.list_str.1", "a"),
+        ("model_default.list_str.2", "b"),
+        ("model_default.int_field", 5),
+        ("model_default.str_field", "default"),
+        ("model_list.1.list_str.1", "A"),
+        ("model_list.1.list_str.2", "B"),
+        ("model_list.1.list_str.3", "C"),
+        ("model_list.1.int_field", 0),
+        ("model_list.1.str_field", "string from first model in list"),
+        ("model_list.2.int_field", 15),
+        ("model_list.2.str_field", ""),
+    ]
+)
 
 
 # ------ Data for remapping test cases ------
 class ChildModel(ParserModel):
-    some_field: str = ''
+    some_field: str = ""
 
     def field_name_to_header_name(field):
         field_map = {
-            "some_field" : "my_field",
+            "some_field": "my_field",
         }
         return field_map.get(field, field)
 
+
 class ModelWithRemap(ParserModel):
-    str_field: str = ''
-    new_str_field: str = ''
+    str_field: str = ""
+    new_str_field: str = ""
     list_field: List[str] = []
     child_field: Optional[ChildModel]
 
     def field_name_to_header_name(field):
         field_map = {
-            "new_str_field" : "str_field_2",
-            "list_field" : "cool_list",
+            "new_str_field": "str_field_2",
+            "list_field": "cool_list",
         }
         return field_map.get(field, field)
 
-input_remap = ModelWithRemap(**{
-    'str_field' : 'main model string',
-    'new_str_field' : 'new string',
-    'list_field' : ['cool', 'list'],
-    'child_field' : {
-        'some_field' : 'some value'
-    }
-})
 
-output_remap_exp = OrderedDict([
-    ('str_field', 'main model string'),
-    ('str_field_2', 'new string'),
-    ('cool_list.1', 'cool'),
-    ('cool_list.2', 'list'),
-    ('child_field.my_field', 'some value'),
-])
+input_remap = ModelWithRemap(
+    **{
+        "str_field": "main model string",
+        "new_str_field": "new string",
+        "list_field": ["cool", "list"],
+        "child_field": {"some_field": "some value"},
+    }
+)
+
+output_remap_exp = OrderedDict(
+    [
+        ("str_field", "main model string"),
+        ("str_field_2", "new string"),
+        ("cool_list.1", "cool"),
+        ("cool_list.2", "list"),
+        ("child_field.my_field", "some value"),
+    ]
+)
 
 
 class TestUnparse(unittest.TestCase):
-
     def setUp(self):
         self.parser = RowParser(MainModel, MockCellParser())
 
@@ -171,5 +184,5 @@ class TestUnparse(unittest.TestCase):
         self.assertEqual(output_remap, output_remap_exp)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -11,7 +11,7 @@ def get_dict_from_csv(csv_file_path):
         return [row for row in csv_reader]
 
 
-def get_table_from_file(file_path, file_format='csv'):
+def get_table_from_file(file_path, file_format="csv"):
     # format: Import file format.
     #     Supported file formats as supported by tablib,
     #     see https://tablib.readthedocs.io/en/stable/formats.html
@@ -24,8 +24,11 @@ def get_table_from_file(file_path, file_format='csv'):
 # TODO: Implement some kind of check that uuids are unique whereever
 # they are supposed to be unique?
 
+
 class Context(object):
-    def __init__(self, group_names=None, inputs=None, random_choices=None, variables=None):
+    def __init__(
+        self, group_names=None, inputs=None, random_choices=None, variables=None
+    ):
         if group_names is not None:
             self.group_names = group_names
         else:
@@ -48,7 +51,7 @@ class Context(object):
 
 
 def find_node_by_uuid(flow, node_uuid):
-    '''Given a node uuid, finds the corresponding node.
+    """Given a node uuid, finds the corresponding node.
 
     Args:
         flow: flow to search in
@@ -57,7 +60,7 @@ def find_node_by_uuid(flow, node_uuid):
     Returns:
         node with uuid matchign node_uuid
         None if no node was found.
-    '''
+    """
 
     for node in flow["nodes"]:
         if node["uuid"] == node_uuid:
@@ -66,19 +69,19 @@ def find_node_by_uuid(flow, node_uuid):
 
 
 def find_destination_uuid(current_node, context):
-    '''
+    """
     For a given node, find the next node that is visited and return its uuid.
 
     The groups the user is in may affect the outcome.
 
     Args:
-        current_node: 
+        current_node:
         group_names (`list` of `str`): groups the user is in
 
     Returns:
         uuid of the node visited after this node.
         Maybe be None if it is the last node.
-    '''
+    """
 
     # By default, choose the first exit.
     destination_uuid = current_node["exits"][0].get("destination_uuid", None)
@@ -97,11 +100,16 @@ def find_destination_uuid(current_node, context):
 
             # Find the case that applies here and get its category_uuid
             # The arguments are not parse (e.g. no variable substitution)
-            category_uuid = router["default_category_uuid"]  # The "Other" option (default)
+            category_uuid = router[
+                "default_category_uuid"
+            ]  # The "Other" option (default)
             if operand is None:
                 # Input "None" indicates No Response if the router has a wait.
                 if "wait" in router:
-                    if "timeout" in router["wait"] and router["wait"]["timeout"]["seconds"] > 0:
+                    if (
+                        "timeout" in router["wait"]
+                        and router["wait"]["timeout"]["seconds"] > 0
+                    ):
                         category_uuid = router["wait"]["timeout"]["category_uuid"]
                     else:
                         return None  # We're stuck here forever --> exit here.
@@ -132,14 +140,18 @@ def find_destination_uuid(current_node, context):
                             break
                     elif case["type"] == "has_text":
                         if case["arguments"] != []:
-                            raise ValueError("has_text case type must not have arguments")
+                            raise ValueError(
+                                "has_text case type must not have arguments"
+                            )
                         if operand.strip() != "":
                             category_uuid = case["category_uuid"]
                             break
                     elif case["type"] == "has_email":
                         if case["arguments"] != []:
-                            raise ValueError("has_email case type must not have arguments")
-                        if len(re.findall(r'[\w]+@[\w]+\.[\w]+', operand)) > 0:
+                            raise ValueError(
+                                "has_email case type must not have arguments"
+                            )
+                        if len(re.findall(r"[\w]+@[\w]+\.[\w]+", operand)) > 0:
                             # This might differ from the RapidPro implementation.
                             category_uuid = case["category_uuid"]
                             break
@@ -151,7 +163,9 @@ def find_destination_uuid(current_node, context):
                             number = float(operand)
                         except ValueError:
                             number = None
-                        if number is not None and float(case["arguments"][0]) <= number <= float(case["arguments"][1]):
+                        if number is not None and float(
+                            case["arguments"][0]
+                        ) <= number <= float(case["arguments"][1]):
                             category_uuid = case["category_uuid"]
                             break
 
@@ -161,53 +175,61 @@ def find_destination_uuid(current_node, context):
                 if category["uuid"] == category_uuid:
                     exit_uuid = category["exit_uuid"]
             if exit_uuid is None:
-                raise ValueError("No valid exit_uuid in router of node with uuid " + current_node["uuid"])
+                raise ValueError(
+                    "No valid exit_uuid in router of node with uuid "
+                    + current_node["uuid"]
+                )
         else:  # router["type"] == "random"
             # Get the exit_uuid from a random category
             random_choice = context.random_choices.pop(0)
             exit_uuid = router["categories"][random_choice]["exit_uuid"]
 
         # Find the exit we take here and get its destination_uuid
-        destination_uuid = -1  # -1 because None is a valid value indicating the end of a flow
+        destination_uuid = (
+            -1
+        )  # -1 because None is a valid value indicating the end of a flow
         for exit in current_node["exits"]:
             if exit["uuid"] == exit_uuid:
                 destination_uuid = exit.get("destination_uuid", None)
                 break
         if destination_uuid == -1:
-            raise ValueError("No valid destination_uuid in router of node with uuid " + current_node["uuid"])
+            raise ValueError(
+                "No valid destination_uuid in router of node with uuid "
+                + current_node["uuid"]
+            )
     return destination_uuid
 
 
 # List of actions: https://app.rapidpro.io/mr/docs/flows.html#actions
 action_value_fields = {
-    "add_contact_groups" : (lambda x: x["groups"][0]["name"]),
-    "add_contact_urn" : (lambda x: x["path"]),
-    "add_input_labels" : (lambda x: x["labels"][0]["name"]),
-    "call_classifier" : (lambda x: x["classified"]["name"]),
-    "call_resthook" : (lambda x: x["resthook"]),
-    "call_webhook" : (lambda x: x["url"]),
-    "enter_flow" : (lambda x: x["flow"]["name"]),
-    "open_ticket" : (lambda x: x["subject"]),
-    "play_audio" : (lambda x: x["audio_url"]),
-    "remove_contact_groups" : (lambda x: x["groups"][0]["name"]),
-    "say_msg" : (lambda x: x["text"]),
-    "send_broadcast" : (lambda x: x["text"]),
-    "send_email" : (lambda x: x["subject"]),
-    "send_msg" : (lambda x: x["text"]),
-    "set_contact_channel" : (lambda x: x["channel"]["name"]),
-    "set_contact_field" : (lambda x: x["field"]["name"]),
-    "set_contact_language" : (lambda x: x["language"]),
-    "set_contact_name" : (lambda x: x["name"]),
-    "set_contact_status" : (lambda x: x["status"]),
-    "set_contact_timezone" : (lambda x: x["timezone"]),
-    "set_run_result" : (lambda x: x["name"]),
-    "start_session" : (lambda x: x["flow"]["name"]),
-    "transfer_airtime" : (lambda x: "Amount"),
+    "add_contact_groups": (lambda x: x["groups"][0]["name"]),
+    "add_contact_urn": (lambda x: x["path"]),
+    "add_input_labels": (lambda x: x["labels"][0]["name"]),
+    "call_classifier": (lambda x: x["classified"]["name"]),
+    "call_resthook": (lambda x: x["resthook"]),
+    "call_webhook": (lambda x: x["url"]),
+    "enter_flow": (lambda x: x["flow"]["name"]),
+    "open_ticket": (lambda x: x["subject"]),
+    "play_audio": (lambda x: x["audio_url"]),
+    "remove_contact_groups": (lambda x: x["groups"][0]["name"]),
+    "say_msg": (lambda x: x["text"]),
+    "send_broadcast": (lambda x: x["text"]),
+    "send_email": (lambda x: x["subject"]),
+    "send_msg": (lambda x: x["text"]),
+    "set_contact_channel": (lambda x: x["channel"]["name"]),
+    "set_contact_field": (lambda x: x["field"]["name"]),
+    "set_contact_language": (lambda x: x["language"]),
+    "set_contact_name": (lambda x: x["name"]),
+    "set_contact_status": (lambda x: x["status"]),
+    "set_contact_timezone": (lambda x: x["timezone"]),
+    "set_run_result": (lambda x: x["name"]),
+    "start_session": (lambda x: x["flow"]["name"]),
+    "transfer_airtime": (lambda x: "Amount"),
 }
 
 
 def process_actions(node, context):
-    '''May modify the context.'''
+    """May modify the context."""
 
     outputs = []
     for action in node["actions"]:
@@ -231,7 +253,7 @@ def process_actions(node, context):
 
 
 def traverse_flow(flow, context):
-    '''
+    """
     Traverse a given flow, assuming the user's group memberships
     as specified in group_names, which determine which path through
     the flow is taken.
@@ -247,7 +269,7 @@ def traverse_flow(flow, context):
 
     Only supports send_msg actions and group switches
     TODO: Abort after too many steps (there may be cycles).
-    '''
+    """
 
     outputs = []
     current_node = flow["nodes"][0]
@@ -264,17 +286,16 @@ def traverse_flow(flow, context):
 
 
 def find_final_destination(flow, node, context):
-    '''Starting at node in flow, traverse the flow until we reach a
+    """Starting at node in flow, traverse the flow until we reach a
     destination that is not contained inside the flow.
     TODO: Abort after too many steps (there may be cycles).
 
     Returns:
         uuid of the destination outside the flow
-    '''
+    """
 
     while node is not None:
         process_actions(node, context)
         destination_uuid = find_destination_uuid(node, context)
         node = find_node_by_uuid(flow, destination_uuid)
     return destination_uuid
-


### PR DESCRIPTION
This project does not follow any particular code style conventions, which is a distraction to some (me, in particular), but has the general effect of making the code harder to read and edit. As an example, some modules use tabs for indentation and others use spaces. Good code style depends entirely on programmers' individual choices.

[Black] is an opinionated code formatter with intentionally limited configuration options, so that developers spend less time thinking about code style. The intention is for Black to make the vast majority of code style decisions and make a consistent style more likely throughout the project.

This PR applies Black coding style to the entire project in one attempt, as is [recommended] by the Black documentation. Black is guaranteed not to change the behaviour of the code it is applied to.

[Black]: https://black.readthedocs.io/en/stable/index.html
[recommended]: https://black.readthedocs.io/en/stable/guides/introducing_black_to_your_project.html