### PR TITLE
Return dict representing RapidPro flow from create_flows function

### DIFF
--- a/src/rpft/cli.py
+++ b/src/rpft/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 
 from rpft.converters import create_flows
 from rpft.logger.logger import initialize_main_logger
@@ -8,13 +9,16 @@ LOGGER = initialize_main_logger()
 
 def main():
     args = create_parser().parse_args()
-    create_flows(
+    flows = create_flows(
         args.input,
-        args.output,
+        None,
         args.format,
         data_models=args.datamodels,
         tags=args.tags,
     )
+
+    with open(args.output, "w") as export:
+        json.dump(flows, export, indent=4)
 
 
 def create_parser():
@@ -23,8 +27,8 @@ def create_parser():
             "Generate RapidPro flows JSON from spreadsheets\n"
             "\n"
             "Example usage:\n"
-            "create_flows --output=flows.json --format=csv "
-            "--datamodels=example.models sheet1.csv sheet2.csv"
+            "create_flows --output=flows.json --format=csv --datamodels=example.models"
+            " sheet1.csv sheet2.csv"
         ),
         formatter_class=argparse.RawTextHelpFormatter,
     )
@@ -41,7 +45,8 @@ def create_parser():
         nargs="+",
         help=(
             "CSV/XLSX: path to files on local file system\n"
-            "Google Sheets: sheet ID i.e. https://docs.google.com/spreadsheets/d/[ID]/edit"
+            "Google Sheets: sheet ID i.e."
+            " https://docs.google.com/spreadsheets/d/[ID]/edit"
         ),
     )
     parser.add_argument("-o", "--output", required=True, help="Output JSON filename")
@@ -49,7 +54,7 @@ def create_parser():
         "-f",
         "--format",
         required=True,
-        choices=["csv", "xlsx", "google_sheets"],
+        choices=["csv", "google_sheets", "xlsx"],
         help="Input sheet format",
     )
     parser.add_argument(

--- a/src/rpft/converters.py
+++ b/src/rpft/converters.py
@@ -8,6 +8,16 @@ from rpft.parsers.sheets import CSVSheetReader, GoogleSheetReader, XLSXSheetRead
 
 
 def create_flows(input_files, output_file, sheet_format, data_models=None, tags=[]):
+    """
+    Convert source spreadsheet(s) into RapidPro flows.
+
+    :param sources: list of source spreadsheets to convert
+    :param output_files: (deprecated) path of file to export flows to as JSON
+    :param sheet_format: format of the spreadsheets
+    :param data_models: name of module containing supporting Python data classes
+    :param tags: names of tags to be used to filter the source spreadsheets
+    :returns: dict representing the RapidPro import/export format.
+    """
     parser = ContentIndexParser(
         user_data_model_module_name=data_models, tag_matcher=TagMatcher(tags)
     )
@@ -16,7 +26,13 @@ def create_flows(input_files, output_file, sheet_format, data_models=None, tags=
         reader = create_sheet_reader(sheet_format, input_file)
         parser.add_content_index(reader)
 
-    json.dump(parser.parse_all().render(), open(output_file, "w"), indent=4)
+    flows = parser.parse_all().render()
+
+    if output_file:
+        with open(output_file, "w") as export:
+            json.dump(flows, export, indent=4)
+
+    return flows
 
 
 def create_sheet_reader(sheet_format, input_file, credentials=None):


### PR DESCRIPTION
The decision to write files to the file system should be left to the caller. We always return a dict in case further processing of the flows is required after conversion from source spreadsheets.

The `output_files` argument is deprecated and will be removed in future. Anyone calling `create_flows` should pass in `None` for `output_files` and write a file themselves, if they wish.