### PR TITLE
Data sheet manipulation operations

### DIFF
--- a/src/rpft/parsers/creation/contentindexparser.py
+++ b/src/rpft/parsers/creation/contentindexparser.py
@@ -175,13 +175,19 @@ class ContentIndexParser:
                 "has to be provided"
             )
         sheet_names = row.sheet_name
-        if row.operation.type != "concat" and len(sheet_names) > 1:
+        if row.operation.type in ["filter", "sort"] and len(sheet_names) > 1:
             LOGGER.warning(
-                "data_sheet definition take only one sheet_name, unless the operation "
-                "concat is used. All but the first sheet_name are ignored."
+                "data_sheet definition take only one sheet_name for filter and sort "
+                "operations. All but the first sheet_name are ignored."
             )
         if not row.operation.type:
-            data_sheet = self._get_data_sheet(sheet_names[0], row.data_model)
+            if len(sheet_names) > 1:
+                LOGGER.warning(
+                    "Implicitly concatenating data sheets without concat operation. "
+                    "Implicit concatenation is deprecated and may be removed "
+                    "in the future."
+                )
+            data_sheet = self._data_sheets_concat(sheet_names, row.data_model)
         else:
             if not row.new_name:
                 LOGGER.critical(

--- a/src/rpft/parsers/creation/contentindexparser.py
+++ b/src/rpft/parsers/creation/contentindexparser.py
@@ -31,9 +31,6 @@ class DataSheet:
         self.rows = rows
         self.row_model = row_model
 
-    def __getitem__(self, key):
-        return self.rows[key]
-
 
 class ParserError(Exception):
     pass
@@ -292,7 +289,7 @@ class ContentIndexParser:
         return DataSheet(new_row_data, data_sheet.row_model)
 
     def get_data_sheet_row(self, sheet_name, row_id):
-        return self.data_sheets[sheet_name][row_id]
+        return self.data_sheets[sheet_name].rows[row_id]
 
     def get_data_sheet_rows(self, sheet_name):
         return self.data_sheets[sheet_name].rows
@@ -454,6 +451,6 @@ class ContentIndexParser:
                     f'Required template argument "{arg_def.name}" not provided'
                 )
             if arg_def.type == "sheet":
-                context[arg_def.name] = self.data_sheets[arg_value]
+                context[arg_def.name] = self.get_data_sheet_rows(arg_value)
             else:
                 context[arg_def.name] = arg_value

--- a/src/rpft/parsers/creation/contentindexparser.py
+++ b/src/rpft/parsers/creation/contentindexparser.py
@@ -22,6 +22,19 @@ class TemplateSheet:
         self.argument_definitions = argument_definitions
 
 
+class DataSheet:
+    def __init__(self, rows, row_model):
+        """Args:
+        rows: A dict mapping row_ids (str) to row_model instances.
+        row_model: the model underlying the instances of rows.
+        """
+        self.rows = rows
+        self.row_model = row_model
+
+    def __getitem__(self, key):
+        return self.rows[key]
+
+
 class ParserError(Exception):
     pass
 
@@ -35,8 +48,8 @@ class ContentIndexParser:
     ):
         self.reader = sheet_reader
         self.tag_matcher = tag_matcher
-        self.template_sheets = {}  # values: tablib tables
-        self.data_sheets = {}  # values: OrderedDicts of RowModels
+        self.template_sheets = {}
+        self.data_sheets = {}
         self.flow_definition_rows = []  # list of ContentIndexRowModel
         self.campaign_parsers = {}  # list of CampaignParser
 
@@ -82,9 +95,7 @@ class ContentIndexParser:
                             "For data_sheet rows, at least one "
                             "sheet_name has to be specified"
                         )
-                    self._process_data_sheet(
-                        row.sheet_name, row.new_name, row.data_model
-                    )
+                    self._process_data_sheet(row)
                 elif row.type in ["template_definition", "create_flow"]:
                     if not len(row.sheet_name) == 1:
                         LOGGER.critical(
@@ -157,51 +168,86 @@ class ContentIndexParser:
 
         return active
 
-    def _process_data_sheet(self, sheet_names, new_name, data_model_name):
+    def _process_data_sheet(self, row):
         if not hasattr(self, "user_models_module"):
             LOGGER.critical(
                 "If there are data sheets, a user_data_model_module_name "
                 "has to be provided"
             )
-            return
-        if not data_model_name:
-            LOGGER.critical("No data_model_name provided for data sheet.")
-            return
-        if len(sheet_names) > 1 and not new_name:
-            LOGGER.critical(
-                "If multiple sheets are concatenated, a new_name has to be provided"
+        sheet_names = row.sheet_name
+        if row.operation != "concat" and len(sheet_names) > 1:
+            LOGGER.warning(
+                "data_sheet definition take only one sheet_name, unless the operation "
+                "concat is used. All but the first sheet_name are ignored."
             )
-            return
-        if not new_name:
-            new_name = sheet_names[0]
+        if not row.operation:
+            data_sheet = self._get_data_sheet(sheet_names[0], row.data_model)
+        else:
+            if not row.new_name:
+                LOGGER.critical(
+                    "If an operation is applied to a data_sheet, "
+                    "a new_name has to be provided"
+                )
+            if row.operation == "concat":
+                data_sheet = self._data_sheets_concat(row.sheet_name, row.data_model)
+            elif row.operation == "filter":
+                raise NotImplementedError()
+            elif row.operation == "sort":
+                raise NotImplementedError()
+            else:
+                LOGGER.critical(f'Unknown operation "{row.operation}"')
+        new_name = row.new_name or sheet_names[0]
         if new_name in self.data_sheets:
             LOGGER.warn(
                 f"Duplicate data sheet {new_name}. Overwriting previous definition."
             )
-        content = OrderedDict()
+        self.data_sheets[new_name] = data_sheet
+
+    def _get_data_sheet(self, sheet_name, data_model_name):
+        if sheet_name in self.data_sheets:
+            return self.data_sheets[sheet_name]
+        else:
+            return self._get_new_data_sheet(sheet_name, data_model_name)
+
+    def _get_new_data_sheet(self, sheet_name, data_model_name):
+        if not data_model_name:
+            LOGGER.critical("No data_model_name provided for data sheet.")
+        try:
+            user_model = getattr(self.user_models_module, data_model_name)
+        except AttributeError:
+            LOGGER.critical(
+                f'Undefined data_model_name "{data_model_name}" '
+                f"in {self.user_models_module}."
+            )
+        data_table = self._get_sheet_or_die(sheet_name)
+        with logging_context(sheet_name):
+            data_table = self._get_sheet_or_die(sheet_name).table
+            row_parser = RowParser(user_model, CellParser())
+            sheet_parser = SheetParser(row_parser, data_table)
+            data_rows = sheet_parser.parse_all()
+            model_instances = OrderedDict((row.ID, row) for row in data_rows)
+            return DataSheet(model_instances, user_model)
+
+    def _data_sheets_concat(self, sheet_names, data_model_name):
+        all_data_rows = OrderedDict()
+        user_model = None
         for sheet_name in sheet_names:
             with logging_context(sheet_name):
-                data_table = self._get_sheet_or_die(sheet_name).table
-                try:
-                    user_model = getattr(self.user_models_module, data_model_name)
-                except AttributeError:
+                data_sheet = self._get_data_sheet(sheet_name, data_model_name)
+                if user_model and user_model is not data_sheet.row_model:
                     LOGGER.critical(
-                        f'Undefined data_model_name "{data_model_name}" '
-                        f"in {self.user_models_module}."
+                        "Cannot concatenate data_sheets with different "
+                        "underlying models"
                     )
-                    return
-                row_parser = RowParser(user_model, CellParser())
-                sheet_parser = SheetParser(row_parser, data_table)
-                data_rows = sheet_parser.parse_all()
-                sheet_content = OrderedDict((row.ID, row) for row in data_rows)
-                content.update(sheet_content)
-        self.data_sheets[new_name] = content
+                user_model = data_sheet.row_model
+                all_data_rows.update(data_sheet.rows)
+        return DataSheet(all_data_rows, user_model)
 
-    def get_data_model_instance(self, sheet_name, row_id):
+    def get_data_sheet_row(self, sheet_name, row_id):
         return self.data_sheets[sheet_name][row_id]
 
-    def get_all_data_model_instances(self, sheet_name):
-        return self.data_sheets[sheet_name]
+    def get_data_sheet_rows(self, sheet_name):
+        return self.data_sheets[sheet_name].rows
 
     def get_template_sheet(self, name):
         return self.template_sheets[name]
@@ -251,7 +297,7 @@ class ContentIndexParser:
         for logging_prefix, row in self.flow_definition_rows:
             with logging_context(f"{logging_prefix} | {row.sheet_name[0]}"):
                 if row.data_sheet and not row.data_row_id:
-                    data_rows = self.get_all_data_model_instances(row.data_sheet)
+                    data_rows = self.get_data_sheet_rows(row.data_sheet)
                     for data_row_id in data_rows.keys():
                         with logging_context(f'with data_row_id "{data_row_id}"'):
                             flow = self._parse_flow(
@@ -304,7 +350,7 @@ class ContentIndexParser:
         base_name = new_name or sheet_name
         if data_sheet and data_row_id:
             flow_name = " - ".join([base_name, data_row_id])
-            context = self.get_data_model_instance(data_sheet, data_row_id)
+            context = self.get_data_sheet_row(data_sheet, data_row_id)
         else:
             if data_sheet or data_row_id:
                 LOGGER.warn(
@@ -341,7 +387,7 @@ class ContentIndexParser:
             # Check if these args are non-empty.
             # Once the row parser is cleaned up to eliminate trailing ''
             # entries, this won't be necessary
-            extra_args = args[len(arg_defs):]
+            extra_args = args[len(arg_defs) :]
             non_empty_extra_args = [ea for ea in extra_args if ea]
             if non_empty_extra_args:
                 LOGGER.warn("Too many arguments provided to template")

--- a/src/rpft/parsers/creation/contentindexrowmodel.py
+++ b/src/rpft/parsers/creation/contentindexrowmodel.py
@@ -8,6 +8,11 @@ class TemplateArgument(ParserModel):
     default_value: str = ""
 
 
+class Operation(ParserModel):
+    type: str = ""
+    expression: str = ""
+
+
 class ContentIndexRowModel(ParserModel):
     type: str = ""
     new_name: str = ""
@@ -16,8 +21,7 @@ class ContentIndexRowModel(ParserModel):
     data_row_id: str = ""
     template_argument_definitions: List[TemplateArgument] = []  # internal name
     template_arguments: list = []
-    operation: str = ""
-    arguments: str = ""
+    operation: Operation = Operation()
     data_model: str = ""
     group: str = ""
     status: str = ""

--- a/src/rpft/parsers/creation/contentindexrowmodel.py
+++ b/src/rpft/parsers/creation/contentindexrowmodel.py
@@ -1,5 +1,6 @@
-from rpft.parsers.common.rowparser import ParserModel
 from typing import List
+
+from rpft.parsers.common.rowparser import ParserModel
 
 
 class TemplateArgument(ParserModel):
@@ -11,6 +12,7 @@ class TemplateArgument(ParserModel):
 class Operation(ParserModel):
     type: str = ""
     expression: str = ""
+    order: str = ""
 
 
 class ContentIndexRowModel(ParserModel):

--- a/src/rpft/parsers/creation/contentindexrowmodel.py
+++ b/src/rpft/parsers/creation/contentindexrowmodel.py
@@ -16,6 +16,8 @@ class ContentIndexRowModel(ParserModel):
     data_row_id: str = ""
     template_argument_definitions: List[TemplateArgument] = []  # internal name
     template_arguments: list = []
+    operation: str = ""
+    arguments: str = ""
     data_model: str = ""
     group: str = ""
     status: str = ""

--- a/tests/test_contentindexparser.py
+++ b/tests/test_contentindexparser.py
@@ -83,18 +83,41 @@ class TestParsing(TestTemplate):
 
         sheet_reader = MockSheetReader(ci_sheet, {"simpledata": simpledata})
         ci_parser = ContentIndexParser(sheet_reader, "tests.datarowmodels.simplemodel")
-        datamodelA = ci_parser.get_data_model_instance("simpledata", "rowA")
-        datamodelB = ci_parser.get_data_model_instance("simpledata", "rowB")
+        datamodelA = ci_parser.get_data_sheet_row("simpledata", "rowA")
+        datamodelB = ci_parser.get_data_sheet_row("simpledata", "rowB")
         self.assertEqual(datamodelA.value1, "1A")
         self.assertEqual(datamodelA.value2, "2A")
         self.assertEqual(datamodelB.value1, "1B")
         self.assertEqual(datamodelB.value2, "2B")
 
     def test_concat(self):
+        # Concatenate two fresh sheets
         ci_sheet = (
-            "type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n"
-            "data_sheet,simpleA;simpleB,,,simpledata,SimpleRowModel,\n"
+            "type,sheet_name,data_sheet,data_row_id,new_name,data_model,operation\n"
+            "data_sheet,simpleA;simpleB,,,simpledata,SimpleRowModel,concat\n"
         )
+        self.check_concat(ci_sheet)
+
+    def test_concat2(self):
+        # Concatenate a fresh sheet with an existing sheet
+        ci_sheet = (
+            "type,sheet_name,data_sheet,data_row_id,new_name,data_model,operation\n"
+            "data_sheet,simpleA,,,renamedA,SimpleRowModel,\n"
+            "data_sheet,renamedA;simpleB,,,simpledata,SimpleRowModel,concat\n"
+        )
+        self.check_concat(ci_sheet)
+
+    def test_concat3(self):
+        # Concatenate two existing sheets
+        ci_sheet = (
+            "type,sheet_name,data_sheet,data_row_id,new_name,data_model,operation\n"
+            "data_sheet,simpleA,,,renamedA,SimpleRowModel,\n"
+            "data_sheet,simpleB,,,renamedB,SimpleRowModel,\n"
+            "data_sheet,renamedA;renamedB,,,simpledata,SimpleRowModel,concat\n"
+        )
+        self.check_concat(ci_sheet)
+
+    def check_concat(self, ci_sheet):
         simpleA = "ID,value1,value2\n" "rowA,1A,2A\n"
         simpleB = "ID,value1,value2\n" "rowB,1B,2B\n"
         sheet_dict = {
@@ -104,8 +127,8 @@ class TestParsing(TestTemplate):
 
         sheet_reader = MockSheetReader(ci_sheet, sheet_dict)
         ci_parser = ContentIndexParser(sheet_reader, "tests.datarowmodels.simplemodel")
-        datamodelA = ci_parser.get_data_model_instance("simpledata", "rowA")
-        datamodelB = ci_parser.get_data_model_instance("simpledata", "rowB")
+        datamodelA = ci_parser.get_data_sheet_row("simpledata", "rowA")
+        datamodelB = ci_parser.get_data_sheet_row("simpledata", "rowB")
         self.assertEqual(datamodelA.value1, "1A")
         self.assertEqual(datamodelA.value2, "2A")
         self.assertEqual(datamodelB.value1, "1B")

--- a/tests/test_contentindexparser.py
+++ b/tests/test_contentindexparser.py
@@ -569,6 +569,14 @@ class TestOperation(unittest.TestCase):
         )
         self.check_concat(ci_sheet)
 
+    def test_concat_implicit(self):
+        # Concatenate two fresh sheets
+        ci_sheet = (
+            "type,sheet_name,data_sheet,data_row_id,new_name,data_model,operation.type\n"
+            "data_sheet,simpleA;simpleB,,,simpledata,SimpleRowModel,\n"
+        )
+        self.check_concat(ci_sheet)
+
     def test_concat2(self):
         # Concatenate a fresh sheet with an existing sheet
         ci_sheet = (

--- a/tests/test_contentindexparser.py
+++ b/tests/test_contentindexparser.py
@@ -8,6 +8,13 @@ from tests.mocks import MockSheetReader
 from tests.utils import traverse_flow, Context
 
 
+# flake8: noqa: E501
+
+
+def csv_join(*args):
+    return "\n".join(args) + "\n"
+
+
 class TestTemplate(unittest.TestCase):
     def compare_messages(self, render_output, flow_name, messages_exp, context=None):
         flow_found = False
@@ -33,8 +40,9 @@ class TestParsing(TestTemplate):
             "template_definition,my_template,,,,,\n"
             "template_definition,my_template2,,,,,draft\n"
         )
-        my_template = (
-            "row_id,type,from,message_text\n" ",send_message,start,Some text\n"
+        my_template = csv_join(
+            "row_id,type,from,message_text",
+            ",send_message,start,Some text",
         )
 
         sheet_reader = MockSheetReader(ci_sheet, {"my_template": my_template})
@@ -55,11 +63,13 @@ class TestParsing(TestTemplate):
             "type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n"
             "template_definition,my_template2,,,,,\n"
         )
-        my_template = (
-            "row_id,type,from,message_text\n" ",send_message,start,Some text\n"
+        my_template = csv_join(
+            "row_id,type,from,message_text",
+            ",send_message,start,Some text",
         )
-        my_template2 = (
-            "row_id,type,from,message_text\n" ",send_message,start,Other text\n"
+        my_template2 = csv_join(
+            "row_id,type,from,message_text",
+            ",send_message,start,Other text",
         )
         sheet_dict = {
             "ci_sheet2": ci_sheet2,
@@ -79,7 +89,11 @@ class TestParsing(TestTemplate):
             "type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n"
             "data_sheet,simpledata,,,,SimpleRowModel,\n"
         )
-        simpledata = "ID,value1,value2\n" "rowA,1A,2A\n" "rowB,1B,2B\n"
+        simpledata = csv_join(
+            "ID,value1,value2",
+            "rowA,1A,2A",
+            "rowB,1B,2B",
+        )
 
         sheet_reader = MockSheetReader(ci_sheet, {"simpledata": simpledata})
         ci_parser = ContentIndexParser(sheet_reader, "tests.datarowmodels.simplemodel")
@@ -118,8 +132,14 @@ class TestParsing(TestTemplate):
         self.check_concat(ci_sheet)
 
     def check_concat(self, ci_sheet):
-        simpleA = "ID,value1,value2\n" "rowA,1A,2A\n"
-        simpleB = "ID,value1,value2\n" "rowB,1B,2B\n"
+        simpleA = csv_join(
+            "ID,value1,value2",
+            "rowA,1A,2A",
+        )
+        simpleB = csv_join(
+            "ID,value1,value2",
+            "rowB,1B,2B",
+        )
         sheet_dict = {
             "simpleA": simpleA,
             "simpleB": simpleB,
@@ -160,8 +180,9 @@ class TestParsing(TestTemplate):
             ",send_message,start,{{value1}}\n"
             ",send_message,,{{custom_field.happy}} and {{custom_field.sad}}\n"
         )
-        my_basic_flow = (
-            "row_id,type,from,message_text\n" ",send_message,start,Some text\n"
+        my_basic_flow = csv_join(
+            "row_id,type,from,message_text",
+            ",send_message,start,Some text",
         )
         sheet_dict = {
             "nesteddata": nesteddata,
@@ -202,11 +223,13 @@ class TestParsing(TestTemplate):
             "create_flow,my_template,,,,,\n"
             "create_flow,my_template2,,,my_template,,\n"
         )
-        my_template = (
-            "row_id,type,from,message_text\n" ",send_message,start,Some text\n"
+        my_template = csv_join(
+            "row_id,type,from,message_text",
+            ",send_message,start,Some text",
         )
-        my_template2 = (
-            "row_id,type,from,message_text\n" ",send_message,start,Other text\n"
+        my_template2 = csv_join(
+            "row_id,type,from,message_text",
+            ",send_message,start,Other text",
         )
         sheet_dict = {
             "ci_sheet": ci_sheet,
@@ -444,13 +467,20 @@ class TestParsing(TestTemplate):
             "data_sheet,metadata,,,,EvalMetadataModel,,\n"
             "create_flow,flow,content,,,,metadata,\n"
         )
-        metadata = "ID,include_if\n" "a,text\n"
+        metadata = csv_join(
+            "ID,include_if",
+            "a,text",
+        )
         flow = (
             '"row_id","type","from","loop_variable","include_if","message_text"\n'
             ',"send_message",,,,"hello"\n'
             ',"send_message",,,"{@metadata[""a""].include_if|eval == ""yes""@}","{{text}}"\n'
         )
-        content = "ID,text\n" "id1,yes\n" "id2,no\n"
+        content = csv_join(
+            "ID,text",
+            "id1,yes",
+            "id2,no",
+        )
         sheet_dict = {
             "metadata": metadata,
             "content": content,
@@ -592,8 +622,9 @@ class TestParseCampaigns(unittest.TestCase):
             "offset,unit,event_type,delivery_hour,message,relative_to,start_mode,flow\n"
             "15,H,F,,,Created On,I,my_basic_flow\n"
         )
-        my_basic_flow = (
-            "row_id,type,from,message_text\n" ",send_message,start,Some text\n"
+        my_basic_flow = csv_join(
+            "row_id,type,from,message_text",
+            ",send_message,start,Some text",
         )
 
         sheet_reader = MockSheetReader(
@@ -619,9 +650,9 @@ class TestParseCampaigns(unittest.TestCase):
         self.assertIsNone(event.get("base_language"))
 
     def test_parse_message_campaign(self):
-        ci_sheet = (
-            "type,sheet_name,new_name,group\n"
-            "create_campaign,my_campaign,,My Group\n"
+        ci_sheet = csv_join(
+            "type,sheet_name,new_name,group",
+            "create_campaign,my_campaign,,My Group",
         )
         my_campaign = (
             "offset,unit,event_type,delivery_hour,message,relative_to,start_mode,flow\n"
@@ -733,17 +764,17 @@ class TestMultiFile(TestTemplate):
         self.run_minimal(True)
 
     def run_minimal(self, singleindex=False):
-        ci_sheet1 = (
-            "type,sheet_name\n"
-            "create_flow,template\n"
+        ci_sheet1 = csv_join(
+            "type,sheet_name",
+            "create_flow,template",
         )
-        ci_sheet2 = (
-            "type,sheet_name\n"
-            "template_definition,template\n"
+        ci_sheet2 = csv_join(
+            "type,sheet_name",
+            "template_definition,template",
         )
-        template = (
-            "row_id,type,from,message_text\n"
-            ",send_message,start,Hello!\n"
+        template = csv_join(
+            "row_id,type,from,message_text",
+            ",send_message,start,Hello!",
         )
         sheet_dict2 = {
             "template": template,
@@ -781,18 +812,18 @@ class TestMultiFile(TestTemplate):
             "template_definition,template,,,\n"
             "create_flow,template,names,,draft\n"
         )
-        template1 = (
-            "row_id,type,from,message_text\n"
-            ",send_message,start,hello {{name}}\n"
+        template1 = csv_join(
+            "row_id,type,from,message_text",
+            ",send_message,start,hello {{name}}",
         )
-        template2 = (
-            "row_id,type,from,message_text\n"
-            ",send_message,start,hi {{name}}\n"
+        template2 = csv_join(
+            "row_id,type,from,message_text",
+            ",send_message,start,hi {{name}}",
         )
-        names = (
-            "ID,name\n"
-            "a,georg\n"
-            "b,chiara\n"
+        names = csv_join(
+            "ID,name",
+            "a,georg",
+            "b,chiara",
         )
         sheet_dict1 = {
             "template": template1,

--- a/tests/test_contentindexparser.py
+++ b/tests/test_contentindexparser.py
@@ -2,11 +2,10 @@ import unittest
 
 from rpft.parsers.creation.contentindexparser import ContentIndexParser
 from rpft.parsers.creation.tagmatcher import TagMatcher
-from rpft.parsers.sheets import CSVSheetReader, XLSXSheetReader, CompositeSheetReader
+from rpft.parsers.sheets import CompositeSheetReader, CSVSheetReader, XLSXSheetReader
 from tests import TESTS_ROOT
 from tests.mocks import MockSheetReader
-from tests.utils import traverse_flow, Context
-
+from tests.utils import Context, traverse_flow
 
 # flake8: noqa: E501
 
@@ -627,7 +626,7 @@ class TestOperation(unittest.TestCase):
             "data_sheet,simpleA,,,,SimpleRowModel,\n"
             "data_sheet,simpleA,,,simpledata,SimpleRowModel,filter|expression;value2=='fruit'\n"
         )
-        self.check_example1(ci_sheet)
+        self.check_example1(ci_sheet, original="simpleA")
 
     def test_filter_existing_renamed(self):
         ci_sheet = (
@@ -635,17 +634,17 @@ class TestOperation(unittest.TestCase):
             "data_sheet,simpleA,,,renamedA,SimpleRowModel,\n"
             "data_sheet,renamedA,,,simpledata,SimpleRowModel,filter|expression;value2=='fruit'\n"
         )
-        self.check_example1(ci_sheet)
+        self.check_example1(ci_sheet, original="renamedA")
 
-    def check_example1(self, ci_sheet):
+    def check_example1(self, ci_sheet, original=None):
         exp_keys = ["rowA", "rowC"]
-        rows = self.check_filter(ci_sheet, exp_keys)
+        rows = self.check_filtersort(ci_sheet, exp_keys, original)
         self.assertEqual(rows["rowA"].value1, "orange")
         self.assertEqual(rows["rowA"].value2, "fruit")
         self.assertEqual(rows["rowC"].value1, "apple")
         self.assertEqual(rows["rowC"].value2, "fruit")
 
-    def check_filter(self, ci_sheet, exp_keys):
+    def check_filtersort(self, ci_sheet, exp_keys, original=None):
         simple = csv_join(
             "ID,value1,value2",
             "rowA,orange,fruit",
@@ -653,12 +652,20 @@ class TestOperation(unittest.TestCase):
             "rowC,apple,fruit",
             "rowD,Manioc,root",
         )
+        all_keys = ["rowA", "rowB", "rowC", "rowD"]
         sheet_dict = {
             "simpleA": simple,
         }
 
         sheet_reader = MockSheetReader(ci_sheet, sheet_dict)
         ci_parser = ContentIndexParser(sheet_reader, "tests.datarowmodels.simplemodel")
+
+        # Ensure input data hasn't been modified
+        if original:
+            original_rows = ci_parser.get_data_sheet_rows(original)
+            self.assertEqual(list(original_rows.keys()), all_keys)
+
+        # Ensure output data is as expected
         rows = ci_parser.get_data_sheet_rows("simpledata")
         self.assertEqual(len(rows), len(exp_keys))
         self.assertEqual(list(rows.keys()), exp_keys)
@@ -670,7 +677,7 @@ class TestOperation(unittest.TestCase):
             "data_sheet,simpleA,,,simpledata,SimpleRowModel,\"filter|expression;value1 in ['orange','apple']\"\n"
         )
         exp_keys = ["rowA", "rowC"]
-        rows = self.check_filter(ci_sheet, exp_keys)
+        self.check_filtersort(ci_sheet, exp_keys)
 
     def test_filter_fresh3(self):
         ci_sheet = (
@@ -678,7 +685,38 @@ class TestOperation(unittest.TestCase):
             "data_sheet,simpleA,,,simpledata,SimpleRowModel,filter|expression;value1.lower() > 'd'\n"
         )
         exp_keys = ["rowA", "rowB", "rowD"]
-        rows = self.check_filter(ci_sheet, exp_keys)
+        self.check_filtersort(ci_sheet, exp_keys)
+
+    def test_sort(self):
+        ci_sheet = (
+            "type,sheet_name,data_sheet,data_row_id,new_name,data_model,operation\n"
+            "data_sheet,simpleA,,,simpledata,SimpleRowModel,sort|expression;value1.lower()\n"
+        )
+        exp_keys = ["rowC", "rowD", "rowA", "rowB"]
+        rows = self.check_filtersort(ci_sheet, exp_keys)
+        self.assertEqual(rows["rowA"].value1, "orange")
+        self.assertEqual(rows["rowA"].value2, "fruit")
+        self.assertEqual(rows["rowB"].value1, "potato")
+        self.assertEqual(rows["rowC"].value1, "apple")
+        self.assertEqual(rows["rowD"].value1, "Manioc")
+
+    def test_sort_existing(self):
+        ci_sheet = (
+            "type,sheet_name,data_sheet,data_row_id,new_name,data_model,operation\n"
+            "data_sheet,simpleA,,,,SimpleRowModel,\n"
+            "data_sheet,simpleA,,,simpledata,SimpleRowModel,sort|expression;value1.lower()\n"
+        )
+        exp_keys = ["rowC", "rowD", "rowA", "rowB"]
+        self.check_filtersort(ci_sheet, exp_keys, original="simpleA")
+
+    def test_sort_descending(self):
+        ci_sheet = (
+            "type,sheet_name,data_sheet,data_row_id,new_name,data_model,operation\n"
+            "data_sheet,simpleA,,,simpledata,SimpleRowModel,sort|expression;value1.lower()|order;descending\n"
+        )
+        exp_keys = ["rowB", "rowA", "rowD", "rowC"]
+        self.check_filtersort(ci_sheet, exp_keys)
+
 
 class TestParseCampaigns(unittest.TestCase):
     def test_parse_flow_campaign(self):


### PR DESCRIPTION
Introduces operations on data sheets, specifically: Concatenation, filtering and sorting.

In content index sheets, data sheets can be defined by referencing a spreadsheet and a data model, and each row of the spreadsheet is parsed into instances of the data model. The resulting data is stored in an index which is referenced by the `sheet_name` (or `new_name`, if present).

It is now possible to create new entries in this index by taking one (filter, sort) or multiple (concat) existing entries and/or spreadsheet references, and specifying an operation to be performed on in the input. The output is stored in the index under the reference specified by `new_name`.

**Important note**: This breaks backward compatibility in one instance: Previous, it was possible to concatenate sheets implicitly by providing a list of sheets in the `sheet_name` column when defining a data sheet. Now the concatenation has to be made explicit by specifying `concat` as `operation.type`. Without this explicit operation, only the first sheet will be taken and ther others ignored, and a warning will be issued.

Also see https://docs.google.com/document/d/1Onx2RhNoWKW9BQvFrgTc5R5hcwDy1OMsLKnNB7YxQH0/edit

Fixes #103 