### PR TITLE
Filter out Windows-specific newlines

### DIFF
--- a/src/rpft/parsers/sheets.py
+++ b/src/rpft/parsers/sheets.py
@@ -116,11 +116,17 @@ class GoogleSheetReader(AbstractSheetReader):
     def _table_from_content(self, content):
         table = tablib.Dataset()
         table.headers = content[0]
-        n_headers = len(table.headers)
+
         for row in content[1:]:
-            # Pad row to proper length
-            table.append(row + ([""] * (n_headers - len(row))))
+            table.append(self._prepare_row(row, len(table.headers)))
+
         return table
+
+    def _prepare_row(self, row, max_cols):
+        return pad(
+            [cell.replace("\r\n", "\n") for cell in row],
+            max_cols,
+        )
 
     def get_credentials(self):
         sa_creds = os.getenv("CREDENTIALS")
@@ -174,3 +180,7 @@ class CompositeSheetReader:
 def load_csv(path):
     with open(path, mode="r", encoding="utf-8") as csv:
         return tablib.import_set(csv, format="csv")
+
+
+def pad(row, n):
+    return row + ([""] * (n - len(row)))


### PR DESCRIPTION
GoogleSheetReader does not replace '\r\n' character sequences like the CSVSheetReader does. This is because Python automatically converts to '\n' when a file is read. The Google Sheets API preserves the content of cells, so the conversion must be done explicitly by the toolkit.

Closes #115 