### PR TITLE
Support for triggers in ContentIndexParser

### DIFF
--- a/src/rpft/parsers/creation/triggerparser.py
+++ b/src/rpft/parsers/creation/triggerparser.py
@@ -1,0 +1,28 @@
+from rpft.logger.logger import get_logger, logging_context
+from rpft.rapidpro.models.triggers import Trigger
+
+LOGGER = get_logger()
+
+
+class TriggerParser:
+    def __init__(self, sheet_name, rows):
+        self.sheet_name = sheet_name
+        self.rows = rows
+
+    def parse(self):
+        triggers = []
+        for row_idx, row in enumerate(self.rows):
+            with logging_context(f"row {row_idx+2}"):
+                try:
+                    trigger = Trigger(
+                        row.type,
+                        row.keyword,
+                        row.channel,
+                        flow_name=row.flow,
+                        group_names=row.groups,
+                        group_uuids=[],
+                    )
+                    triggers.append(trigger)
+                except ValueError as e:
+                    LOGGER.critical(str(e))
+        return triggers

--- a/src/rpft/parsers/creation/triggerparser.py
+++ b/src/rpft/parsers/creation/triggerparser.py
@@ -16,11 +16,14 @@ class TriggerParser:
                 try:
                     trigger = Trigger(
                         row.type,
-                        row.keyword,
+                        row.keywords,
                         row.channel,
+                        row.match_type,
                         flow_name=row.flow,
                         group_names=row.groups,
                         group_uuids=[],
+                        exclude_group_names=row.exclude_groups,
+                        exclude_group_uuids=[],
                     )
                     triggers.append(trigger)
                 except ValueError as e:

--- a/src/rpft/parsers/creation/triggerrowmodel.py
+++ b/src/rpft/parsers/creation/triggerrowmodel.py
@@ -1,0 +1,21 @@
+from typing import List
+
+from pydantic import validator
+
+from rpft.parsers.common.rowparser import ParserModel
+
+
+class TriggerRowModel(ParserModel):
+    type: str  # K (keyword) or C (uncaught) or M (missed call)
+    keyword: str = ""
+    flow: str = ""
+    groups: List[str] = []
+    channel: str = ""
+
+    @validator("type")
+    def validate_unit(cls, v):
+        if v not in ["K", "C", "M"]:
+            raise ValueError(
+                'type must be "K" (keyword), ' '"C" (uncaught), or "M" (missed call)'
+            )
+        return v

--- a/src/rpft/parsers/creation/triggerrowmodel.py
+++ b/src/rpft/parsers/creation/triggerrowmodel.py
@@ -6,16 +6,27 @@ from rpft.parsers.common.rowparser import ParserModel
 
 
 class TriggerRowModel(ParserModel):
-    type: str  # K (keyword) or C (uncaught) or M (missed call)
-    keyword: str = ""
+    type: str
+    keywords: List[str] = ""
     flow: str = ""
     groups: List[str] = []
+    exclude_groups: List[str] = []
     channel: str = ""
+    match_type: str = ""
 
     @validator("type")
-    def validate_unit(cls, v):
-        if v not in ["K", "C", "M"]:
+    def validate_type(cls, v):
+        if v not in ["K", "C", "M", "T"]:
             raise ValueError(
-                'type must be "K" (keyword), ' '"C" (uncaught), or "M" (missed call)'
+                'type must be "K" (keyword), "C" (uncaught), '
+                '"T" (ticket), or "M" (missed call)'
+            )
+        return v
+
+    @validator("match_type")
+    def validate_match_type(cls, v, values):
+        if values["type"] == "K" and v not in ["F", "O", ""]:
+            raise ValueError(
+                'match_type must be "F" (starts with) or "O" (only) if type is "K".'
             )
         return v

--- a/src/rpft/rapidpro/models/containers.py
+++ b/src/rpft/rapidpro/models/containers.py
@@ -1,10 +1,11 @@
 import copy
 
-from rpft.rapidpro.utils import generate_new_uuid
-from rpft.rapidpro.models.nodes import BaseNode
+from rpft.parsers.creation.flowrowmodel import Edge, FlowRowModel
 from rpft.rapidpro.models.actions import Group
 from rpft.rapidpro.models.campaigns import Campaign
-from rpft.parsers.creation.flowrowmodel import FlowRowModel, Edge
+from rpft.rapidpro.models.nodes import BaseNode
+from rpft.rapidpro.models.triggers import Trigger
+from rpft.rapidpro.utils import generate_new_uuid
 
 
 class RapidProContainer:
@@ -36,9 +37,12 @@ class RapidProContainer:
         campaigns = data_copy.pop("campaigns")
         campaigns = [Campaign.from_dict(campaign) for campaign in campaigns]
         container = RapidProContainer(**data_copy)
+        triggers = data_copy.pop("triggers")
+        triggers = [Trigger.from_dict(trigger) for trigger in triggers]
         container.flows = flows
         container.groups = groups
         container.campaigns = campaigns
+        container.triggers = triggers
         return container
 
     def add_flow(self, flow):
@@ -47,6 +51,9 @@ class RapidProContainer:
 
     def add_campaign(self, campaign):
         self.campaigns.append(campaign)
+
+    def add_trigger(self, trigger):
+        self.triggers.append(trigger)
 
     def record_group_uuid(self, name, uuid):
         self.uuid_dict.record_group_uuid(name, uuid)
@@ -66,11 +73,15 @@ class RapidProContainer:
             flow.record_global_uuids(self.uuid_dict)
         for campaign in self.campaigns:
             campaign.record_global_uuids(self.uuid_dict)
+        for trigger in self.triggers:
+            trigger.record_global_uuids(self.uuid_dict)
         self.uuid_dict.generate_missing_uuids()
         for flow in self.flows:
             flow.assign_global_uuids(self.uuid_dict)
         for campaign in self.campaigns:
             campaign.assign_global_uuids(self.uuid_dict)
+        for trigger in self.triggers:
+            trigger.assign_global_uuids(self.uuid_dict)
 
     def merge(self, container):
         """Merge another RapidPro container into this one.
@@ -93,7 +104,7 @@ class RapidProContainer:
             "flows": [flow.render() for flow in self.flows],
             "groups": [group.render() for group in self.groups],
             "site": self.site,
-            "triggers": self.triggers,
+            "triggers": [trigger.render() for trigger in self.triggers],
             "version": self.version,
         }
 

--- a/src/rpft/rapidpro/models/containers.py
+++ b/src/rpft/rapidpro/models/containers.py
@@ -74,7 +74,7 @@ class RapidProContainer:
         for campaign in self.campaigns:
             campaign.record_global_uuids(self.uuid_dict)
         for trigger in self.triggers:
-            trigger.record_global_uuids(self.uuid_dict)
+            trigger.record_global_uuids(self.uuid_dict, require_existing=True)
         self.uuid_dict.generate_missing_uuids()
         for flow in self.flows:
             flow.assign_global_uuids(self.uuid_dict)
@@ -313,6 +313,9 @@ class UUIDDict:
 
     def get_flow_uuid(self, name):
         return self.flow_dict[name]
+
+    def contains_flow(self, name):
+        return name in self.flow_dict
 
     def get_group_list(self):
         return [Group(name, uuid) for name, uuid in self.group_dict.items()]

--- a/src/rpft/rapidpro/models/triggers.py
+++ b/src/rpft/rapidpro/models/triggers.py
@@ -8,19 +8,27 @@ class Trigger:
     def __init__(
         self,
         trigger_type,
-        keyword=None,
+        keywords=None,
         channel=None,
+        match_type=None,
         flow=None,
         flow_name=None,
         flow_uuid=None,
         groups=None,
         group_names=None,
         group_uuids=None,
+        exclude_groups=None,
+        exclude_group_names=None,
+        exclude_group_uuids=None,
     ):
         self.trigger_type = trigger_type
-        self.keyword = keyword or None
-        if self.trigger_type == "K" and not keyword:
-            raise ValueError('Triggers type "K" must have a keyword')
+        self.keywords = keywords or []
+        self.match_type = match_type or None
+        if self.trigger_type == "K":
+            if not keywords or not keywords[0]:
+                raise ValueError('Triggers of type "K" must have a keyword')
+            if not match_type:
+                self.match_type = "F"
         self.channel = channel or None
         if not flow and not flow_name:
             raise ValueError("Trigger must have flow or a flow_name")
@@ -29,11 +37,24 @@ class Trigger:
             self.groups = groups
         else:
             self.groups = []
-            for group_name, group_uuid in zip_longest(group_names, group_uuids):
-                if not group_name:
-                    raise ValueError("Trigger group must have a name.")
-                group = Group(group_name, group_uuid or None)
-                self.groups.append(group)
+            self._assign_groups(self.groups, group_names, group_uuids)
+        if exclude_groups is not None:
+            self.exclude_groups = exclude_groups
+        else:
+            self.exclude_groups = []
+            if exclude_group_names is not None:
+                self._assign_groups(
+                    self.exclude_groups,
+                    exclude_group_names,
+                    exclude_group_uuids
+                )
+
+    def _assign_groups(self, groups_field, group_names, group_uuids):
+        for group_name, group_uuid in zip_longest(group_names, group_uuids):
+            if not group_name:
+                raise ValueError("Trigger group must have a name.")
+            group = Group(group_name, group_uuid or None)
+            groups_field.append(group)
 
     def from_dict(data):
         data_copy = copy.deepcopy(data)
@@ -43,6 +64,20 @@ class Trigger:
         for group in data_copy["groups"]:
             groups.append(Group.from_dict(group))
         data_copy["groups"] = groups
+        if "exclude_groups" in data_copy:
+            exclude_groups = []
+            for group in data_copy["exclude_groups"]:
+                exclude_groups.append(Group.from_dict(group))
+            data_copy["exclude_groups"] = exclude_groups
+        # Newer versions of RapidPro use a list of keywords instead of a single keyword
+        # If we have "keywords", use that. Otherwise, process the "keyword" entry
+        if "keywords" not in data_copy:
+            assert "keyword" in data_copy
+            data_copy["keywords"] = []
+            if data_copy["keyword"] is not None:
+                data_copy["keywords"].append(data_copy["keyword"])
+        if "keyword" in data_copy:
+            data_copy.pop("keyword")
         return Trigger(**data_copy)
 
     def record_global_uuids(self, uuid_dict):
@@ -51,6 +86,9 @@ class Trigger:
         if self.groups is not None:
             for group in self.groups:
                 group.record_uuid(uuid_dict)
+        if self.exclude_groups is not None:
+            for group in self.exclude_groups:
+                group.record_uuid(uuid_dict)
 
     def assign_global_uuids(self, uuid_dict):
         if self.flow is not None:
@@ -58,12 +96,22 @@ class Trigger:
         if self.groups is not None:
             for group in self.groups:
                 group.assign_uuid(uuid_dict)
+        if self.exclude_groups is not None:
+            for group in self.exclude_groups:
+                group.assign_uuid(uuid_dict)
 
     def render(self):
-        return {
+        # We include both keywords and keyword in the render output
+        # in order to support both newer and older versions of RapidPro
+        render_dict = {
             "trigger_type": self.trigger_type,
-            "keyword": self.keyword,
+            "keyword": self.keywords[0] if self.keywords else None,
+            "keywords": self.keywords,
             "channel": self.channel,
             "flow": self.flow.render(),
             "groups": [group.render() for group in self.groups],
+            "exclude_groups": [group.render() for group in self.exclude_groups],
         }
+        if self.match_type:
+            render_dict.update({"match_type": self.match_type})
+        return render_dict

--- a/src/rpft/rapidpro/models/triggers.py
+++ b/src/rpft/rapidpro/models/triggers.py
@@ -5,7 +5,6 @@ from rpft.rapidpro.models.common import FlowReference, Group
 
 
 class Trigger:
-
     def __init__(
         self,
         trigger_type,
@@ -20,6 +19,8 @@ class Trigger:
     ):
         self.trigger_type = trigger_type
         self.keyword = keyword or None
+        if self.trigger_type == "K" and not keyword:
+            raise ValueError('Triggers type "K" must have a keyword')
         self.channel = channel or None
         if not flow and not flow_name:
             raise ValueError("Trigger must have flow or a flow_name")

--- a/src/rpft/rapidpro/models/triggers.py
+++ b/src/rpft/rapidpro/models/triggers.py
@@ -1,0 +1,68 @@
+import copy
+from itertools import zip_longest
+
+from rpft.rapidpro.models.common import FlowReference, Group
+
+
+class Trigger:
+
+    def __init__(
+        self,
+        trigger_type,
+        keyword=None,
+        channel=None,
+        flow=None,
+        flow_name=None,
+        flow_uuid=None,
+        groups=None,
+        group_names=None,
+        group_uuids=None,
+    ):
+        self.trigger_type = trigger_type
+        self.keyword = keyword or None
+        self.channel = channel or None
+        if not flow and not flow_name:
+            raise ValueError("Trigger must have flow or a flow_name")
+        self.flow = flow or FlowReference(flow_name, flow_uuid)
+        if groups is not None:
+            self.groups = groups
+        else:
+            self.groups = []
+            for group_name, group_uuid in zip_longest(group_names, group_uuids):
+                if not group_name:
+                    raise ValueError("Trigger group must have a name.")
+                group = Group(group_name, group_uuid or None)
+                self.groups.append(group)
+
+    def from_dict(data):
+        data_copy = copy.deepcopy(data)
+        if "flow" in data_copy:
+            data_copy["flow"] = FlowReference(**data_copy["flow"])
+        groups = []
+        for group in data_copy["groups"]:
+            groups.append(Group.from_dict(group))
+        data_copy["groups"] = groups
+        return Trigger(**data_copy)
+
+    def record_global_uuids(self, uuid_dict):
+        if self.flow is not None:
+            self.flow.record_uuid(uuid_dict)
+        if self.groups is not None:
+            for group in self.groups:
+                group.record_uuid(uuid_dict)
+
+    def assign_global_uuids(self, uuid_dict):
+        if self.flow is not None:
+            self.flow.assign_uuid(uuid_dict)
+        if self.groups is not None:
+            for group in self.groups:
+                group.assign_uuid(uuid_dict)
+
+    def render(self):
+        return {
+            "trigger_type": self.trigger_type,
+            "keyword": self.keyword,
+            "channel": self.channel,
+            "flow": self.flow.render(),
+            "groups": [group.render() for group in self.groups],
+        }

--- a/src/rpft/rapidpro/models/triggers.py
+++ b/src/rpft/rapidpro/models/triggers.py
@@ -4,6 +4,10 @@ from itertools import zip_longest
 from rpft.rapidpro.models.common import FlowReference, Group
 
 
+class RapidProTriggerError(Exception):
+    pass
+
+
 class Trigger:
     def __init__(
         self,
@@ -80,7 +84,12 @@ class Trigger:
             data_copy.pop("keyword")
         return Trigger(**data_copy)
 
-    def record_global_uuids(self, uuid_dict):
+    def record_global_uuids(self, uuid_dict, require_existing=False):
+        if require_existing:
+            if not uuid_dict.contains_flow(self.flow.name):
+                raise RapidProTriggerError(
+                    f"Trigger references undefined flow name {self.flow.name}"
+                )
         if self.flow is not None:
             self.flow.record_uuid(uuid_dict)
         if self.groups is not None:

--- a/tests/data/containers/rapidpro_container_trigger.json
+++ b/tests/data/containers/rapidpro_container_trigger.json
@@ -1,0 +1,108 @@
+{
+  "version": "13",
+  "site": "https://rapidpro.idems.international",
+  "flows": [
+    {
+      "name": "flow_with_node",
+      "uuid": "c1a32f07-ff0f-4b8b-a700-360c13f53914",
+      "spec_version": "13.1.0",
+      "language": "base",
+      "type": "messaging",
+      "nodes": [
+        {
+          "uuid": "ee74eaef-e8dd-42bb-965a-03e34cb5ef13",
+          "actions": [
+            {
+              "attachments": [],
+              "text": "1",
+              "type": "send_msg",
+              "quick_replies": [],
+              "uuid": "dd69934b-85e3-49aa-b299-4a203ff46a49"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "05c13aeb-7b9e-497c-9723-6bf4d1413edc",
+              "destination_uuid": "60b0ffd3-6235-438f-b356-ed8f72e5404d"
+            }
+          ]
+        }
+      ],
+      "revision": 63,
+      "expire_after_minutes": 10080,
+      "metadata": {
+        "revision": 62
+      },
+      "localization": {}
+    }
+  ],
+  "campaigns": [],
+  "triggers": [
+    {
+      "trigger_type": "K",
+      "keyword": "the keyword",
+      "flow": {
+        "name": "flow_with_node",
+        "uuid": "c1a32f07-ff0f-4b8b-a700-360c13f53914"
+      },
+      "groups": [],
+      "channel": null
+    },
+    {
+      "trigger_type": "M",
+      "keyword": null,
+      "flow": {
+        "name": "flow_with_node",
+        "uuid": "c1a32f07-ff0f-4b8b-a700-360c13f53914"
+      },
+      "groups": [
+        {
+          "uuid": "8224bfe2-acec-434f-bc7c-14c584fc4bc8",
+          "name": "test group"
+        }
+      ],
+      "channel": null
+    },
+    {
+      "trigger_type": "C",
+      "keyword": null,
+      "flow": {
+        "uuid": "a119cac4-daac-44a2-bb36-39852489c317",
+        "name": "JM - Quiz - Template"
+      },
+      "groups": [
+        {
+          "uuid": "8224bfe2-acec-434f-bc7c-14c584fc4bc8",
+          "name": "test group"
+        },
+        {
+          "uuid": "1c516fb6-316c-43d1-8f6b-9e0031fcee81",
+          "name": "test group 2"
+        }
+      ],
+      "channel": null
+    }
+  ],
+  "fields": [
+    {
+      "key": "favourite_number",
+      "name": "favourite_number",
+      "type": "text"
+    },
+    {
+      "key": "test_variable",
+      "name": "test variable",
+      "type": "text"
+    }
+  ],
+  "groups": [
+    {
+      "uuid": "8224bfe2-acec-434f-bc7c-14c584fc4bc8",
+      "name": "test group"
+    },
+    {
+      "uuid": "1c516fb6-316c-43d1-8f6b-9e0031fcee81",
+      "name": "test group 2"
+    }
+  ]
+}

--- a/tests/data/containers/rapidpro_container_trigger.json
+++ b/tests/data/containers/rapidpro_container_trigger.json
@@ -78,8 +78,8 @@
       "keyword": null,
       "keywords": [],
       "flow": {
-        "uuid": "a119cac4-daac-44a2-bb36-39852489c317",
-        "name": "JM - Quiz - Template"
+        "uuid": "c1a32f07-ff0f-4b8b-a700-360c13f53914",
+        "name": "flow_with_node"
       },
       "exclude_groups": [],
       "groups": [

--- a/tests/data/containers/rapidproprev_container_trigger.json
+++ b/tests/data/containers/rapidproprev_container_trigger.json
@@ -73,8 +73,8 @@
       "trigger_type": "C",
       "keyword": null,
       "flow": {
-        "uuid": "a119cac4-daac-44a2-bb36-39852489c317",
-        "name": "JM - Quiz - Template"
+        "uuid": "c1a32f07-ff0f-4b8b-a700-360c13f53914",
+        "name": "flow_with_node"
       },
       "groups": [
         {

--- a/tests/data/containers/rapidproprev_container_trigger.json
+++ b/tests/data/containers/rapidproprev_container_trigger.json
@@ -41,20 +41,16 @@
     {
       "trigger_type": "K",
       "keyword": "the keyword",
-      "keywords": ["the keyword"],
       "flow": {
         "name": "flow_with_node",
         "uuid": "c1a32f07-ff0f-4b8b-a700-360c13f53914"
       },
       "groups": [],
-      "exclude_groups": [],
-      "match_type": "F",
       "channel": null
     },
     {
       "trigger_type": "M",
       "keyword": null,
-      "keywords": [],
       "flow": {
         "name": "flow_with_node",
         "uuid": "c1a32f07-ff0f-4b8b-a700-360c13f53914"
@@ -76,12 +72,10 @@
     {
       "trigger_type": "C",
       "keyword": null,
-      "keywords": [],
       "flow": {
         "uuid": "a119cac4-daac-44a2-bb36-39852489c317",
         "name": "JM - Quiz - Template"
       },
-      "exclude_groups": [],
       "groups": [
         {
           "uuid": "8224bfe2-acec-434f-bc7c-14c584fc4bc8",

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -4,6 +4,7 @@ from rpft.rapidpro.models.containers import RapidProContainer, FlowContainer
 from rpft.rapidpro.models.actions import Group, AddContactGroupAction
 from rpft.rapidpro.models.nodes import BasicNode, SwitchRouterNode, EnterFlowNode
 from rpft.rapidpro.models.campaigns import Campaign, CampaignEvent
+from rpft.rapidpro.models.triggers import Trigger
 
 
 def get_flow_with_group_and_flow_node():
@@ -130,3 +131,23 @@ class TestRapidProContainer(unittest.TestCase):
         )
         self.assertEqual(rpc.flows[0].nodes[1].actions[0].flow.uuid, "fake-flow-uuid")
         self.assertEqual(rpc.campaigns[0].events[0].flow.uuid, "fake-flow-uuid")
+
+    def test_get_uuids_from_trigger(self):
+        rpc = RapidProContainer()
+        rpc.add_flow(get_flow_with_group_and_flow_node())
+        trigger = Trigger(
+            "K",
+            "keyword",
+            flow_name="Second Flow",
+            flow_uuid="fake-flow-uuid",
+            group_names=["No UUID Group"],
+            group_uuids=["fake-group-uuid"],
+        )
+        rpc.add_trigger(trigger)
+        rpc.update_global_uuids()
+        self.assertEqual(rpc.triggers[0].groups[0].uuid, "fake-group-uuid")
+        self.assertEqual(
+            rpc.flows[0].nodes[0].actions[0].groups[0].uuid, "fake-group-uuid"
+        )
+        self.assertEqual(rpc.flows[0].nodes[1].actions[0].flow.uuid, "fake-flow-uuid")
+        self.assertEqual(rpc.triggers[0].flow.uuid, "fake-flow-uuid")

--- a/tests/test_contentindexparser.py
+++ b/tests/test_contentindexparser.py
@@ -3,6 +3,7 @@ import unittest
 from rpft.parsers.creation.contentindexparser import ContentIndexParser
 from rpft.parsers.creation.tagmatcher import TagMatcher
 from rpft.parsers.sheets import CompositeSheetReader, CSVSheetReader, XLSXSheetReader
+from rpft.rapidpro.models.triggers import RapidProTriggerError
 from tests import TESTS_ROOT
 from tests.mocks import MockSheetReader
 from tests.utils import Context, traverse_flow
@@ -870,6 +871,24 @@ class TestParseTriggers(unittest.TestCase):
         self.assertEqual(groups1[1]["uuid"], othergroup_uuid)
         self.assertEqual(groups2[0]["name"], "My Group")
         self.assertEqual(groups2[0]["uuid"], mygroup_uuid)
+
+    def test_parse_triggers_without_flow(self):
+        ci_sheet = (
+            "type,sheet_name\n"
+            "create_triggers,my_triggers\n"
+        )
+        my_triggers = (
+            "type,keywords,flow,groups,exclude_groups,match_type\n"
+            "K,the word,my_basic_flow,My Group,,\n"
+        )
+
+        sheet_reader = MockSheetReader(
+            ci_sheet, {"my_triggers": my_triggers}
+        )
+        ci_parser = ContentIndexParser(sheet_reader)
+        container = ci_parser.parse_all()
+        with self.assertRaises(RapidProTriggerError):
+            render_output = container.render()
 
 
 class TestParseFromFile(TestTemplate):

--- a/tests/test_contentindexparser.py
+++ b/tests/test_contentindexparser.py
@@ -820,10 +820,11 @@ class TestParseTriggers(unittest.TestCase):
             "create_flow,my_basic_flow\n"
         )
         my_triggers = (
-            "type,keyword,flow,groups\n"
-            "K,the word,my_basic_flow,My Group\n"
-            "C,,my_basic_flow,My Group;Other Group\n"
-            "M,,my_basic_flow,\n"
+            "type,keywords,flow,groups,exclude_groups,match_type\n"
+            "K,the word,my_basic_flow,My Group,,\n"
+            "C,,my_basic_flow,My Group;Other Group,,\n"
+            "M,,my_basic_flow,,My Group,\n"
+            "K,first;second,my_basic_flow,,,F\n"
         )
         my_basic_flow = csv_join(
             "row_id,type,from,message_text",
@@ -842,9 +843,16 @@ class TestParseTriggers(unittest.TestCase):
         self.assertEqual(render_output["triggers"][0]["trigger_type"], "K")
         self.assertEqual(render_output["triggers"][1]["trigger_type"], "C")
         self.assertEqual(render_output["triggers"][2]["trigger_type"], "M")
+        self.assertEqual(render_output["triggers"][0]["keywords"], ["the word"])
         self.assertEqual(render_output["triggers"][0]["keyword"], "the word")
+        self.assertEqual(render_output["triggers"][1]["keywords"], [])
         self.assertIsNone(render_output["triggers"][1]["keyword"])
+        self.assertEqual(render_output["triggers"][2]["keywords"], [])
         self.assertIsNone(render_output["triggers"][2]["keyword"])
+        self.assertEqual(render_output["triggers"][3]["keywords"], ["first", "second"])
+        self.assertEqual(render_output["triggers"][3]["keyword"], "first")
+        self.assertEqual(render_output["triggers"][0]["match_type"], "F")
+        self.assertEqual(render_output["triggers"][3]["match_type"], "F")
         for i in range(3):
             self.assertIsNone(render_output["triggers"][i]["channel"])
             self.assertEqual(
@@ -853,12 +861,15 @@ class TestParseTriggers(unittest.TestCase):
             self.assertEqual(render_output["triggers"][i]["flow"]["uuid"], flow_uuid)
         groups0 = render_output["triggers"][0]["groups"]
         groups1 = render_output["triggers"][1]["groups"]
+        groups2 = render_output["triggers"][2]["exclude_groups"]
         self.assertEqual(groups0[0]["name"], "My Group")
         self.assertEqual(groups0[0]["uuid"], mygroup_uuid)
         self.assertEqual(groups1[0]["name"], "My Group")
         self.assertEqual(groups1[0]["uuid"], mygroup_uuid)
         self.assertEqual(groups1[1]["name"], "Other Group")
         self.assertEqual(groups1[1]["uuid"], othergroup_uuid)
+        self.assertEqual(groups2[0]["name"], "My Group")
+        self.assertEqual(groups2[0]["uuid"], mygroup_uuid)
 
 
 class TestParseFromFile(TestTemplate):

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -103,6 +103,22 @@ class TestImportExport(unittest.TestCase):
             render_output = container.render()
             self.assertEqual(render_output, container_data, msg=filename)
 
+    def test_rapidproprev_container_triggers(self):
+        # Previous versions of RapidPro had a different trigger formats.
+        # Check compatibility in this test.
+        self.maxDiff = None
+        with open(
+            self.data_dir / "containers/rapidpro_container_trigger.json", "r"
+        ) as f:
+            expected_container_data = json.load(f)
+        with open(
+            self.data_dir / "containers/rapidproprev_container_trigger.json", "r"
+        ) as f:
+            container_data = json.load(f)
+        container = RapidProContainer.from_dict(container_data)
+        render_output = container.render()
+        self.assertEqual(render_output, expected_container_data)
+
     def test_campaign_events(self):
         self.maxDiff = None
         filenamesList = self.data_dir.glob("campaigns/event_*.json")


### PR DESCRIPTION
In the content index sheet, the relevant row type is `create_triggers`. The sheet name must reference a valid sheet.

This sheet has 4 important columns (also see [here](https://github.com/IDEMSInternational/rapidpro-flow-toolkit/commit/5d918cf9882c674f0cdd44f1174efb5592162a0f#diff-d937b45d7eae1a46f8be29406fc937ed02fbb25f51affa3fc76423b48ffb6132)):

- `type`: `K` (keyword), `C` (uncaught) or `M` (missed call)
- `keyword`: keyword in case the type is `K`
- `flow`: Name of the flow that gets triggered
- `groups`: List of group names for which the trigger applies (may be empty)

Issues:
- RapidPro's UI supports other triggers, like starting a flow at a given point in time, and a few others, however, none of them seem to work (I was unable to create them, the UI seems buggy).
- Similarly, for keyword triggers, the UI allows to check whether the user's message starts with the keyword or is exactly the keyword, however, during export, this information is lost (these is no field in the json to distinguish between the two).
- There is also a channel field in the UI and the exported JSON, however, I was unable to get it to work in the UI. It is supported as a column in the trigger sheet, and its type is assumed to be string, but I don't know if it works or has any effect. Leave it blank (or leave it out of the column headers altogether) to make sure that its value is set to `null`.

Fixes #92