### PR TITLE
RapidPro models: Check category name length

### DIFF
--- a/src/rpft/parsers/creation/flowparser.py
+++ b/src/rpft/parsers/creation/flowparser.py
@@ -11,7 +11,10 @@ from rpft.rapidpro.models.actions import (
     WhatsAppMessageTemplating,
 )
 from rpft.rapidpro.models.containers import FlowContainer
-from rpft.rapidpro.models.exceptions import RapidProActionError
+from rpft.rapidpro.models.exceptions import (
+    RapidProActionError,
+    RapidProRouterError,
+)
 from rpft.rapidpro.models.nodes import (
     BasicNode,
     SwitchRouterNode,
@@ -117,7 +120,10 @@ class NoOpNodeGroup:
     def add_parent_edge(self, source_node_group, condition):
         self.parent_edges.append(NoOpNodeGroup.ParentEdge(source_node_group, condition))
         if self.router_node is not None:
-            source_node_group.add_exit(self.router_node.uuid, condition)
+            try:
+                source_node_group.add_exit(self.router_node.uuid, condition)
+            except RapidProRouterError as e:
+                LOGGER.critical(str(e))
 
     def add_exit(self, destination_uuid, condition):
         if not self.router_node:
@@ -640,7 +646,10 @@ class FlowParser:
     def _add_row_edge(self, edge, destination_uuid):
         from_node_group = self._get_node_group_from_edge(edge)
         if from_node_group is not None:
-            from_node_group.add_exit(destination_uuid, edge.condition)
+            try:
+                from_node_group.add_exit(destination_uuid, edge.condition)
+            except RapidProRouterError as e:
+                LOGGER.critical(str(e))
 
     def _parse_goto_row(self, row):
         # If there is a single destination, connect all edges to that destination.

--- a/src/rpft/rapidpro/models/exceptions.py
+++ b/src/rpft/rapidpro/models/exceptions.py
@@ -1,3 +1,8 @@
 class RapidProActionError(Exception):
-    "Raise if some parameter of a RapidProAction is invalid."
+    "Raised if some parameter of a RapidProAction is invalid."
+    pass
+
+
+class RapidProRouterError(Exception):
+    "Raised if some parameter of a RapidProRouter is invalid."
     pass

--- a/src/rpft/rapidpro/models/routers.py
+++ b/src/rpft/rapidpro/models/routers.py
@@ -1,6 +1,7 @@
 import logging
 
 from rpft.rapidpro.models.common import Exit
+from rpft.rapidpro.models.exceptions import RapidProRouterError
 from rpft.rapidpro.utils import generate_new_uuid
 from rpft.parsers.creation.flowrowmodel import Condition, Edge
 
@@ -418,6 +419,8 @@ class RouterCategory:
         an exit.
         """
         self.uuid = uuid or generate_new_uuid()
+        if len(name) > 115:
+            raise RapidProRouterError(f"Category name too long (>115): {name}")
         self.name = name
         if exit:
             self.exit = exit


### PR DESCRIPTION
Ensure category names within routers don't exceed 115 characters

Fixes #93 