### PR TITLE
ContentIndexParser: ignore_row row type

### DIFF
--- a/src/rpft/parsers/creation/contentindexparser.py
+++ b/src/rpft/parsers/creation/contentindexparser.py
@@ -98,6 +98,11 @@ class ContentIndexParser:
                     self._process_data_sheet(row)
                 elif row.type in ["template_definition", "create_flow"]:
                     if row.type == "template_definition":
+                        if row.new_name:
+                            LOGGER.warning(
+                                "template_definition does not support 'new_name'; "
+                                f"new_name '{row.new_name}' will be ignored."
+                            )
                         self._add_template(row, True)
                     else:
                         self.flow_definition_rows.append((logging_prefix, row))
@@ -113,6 +118,8 @@ class ContentIndexParser:
                 elif row.type == "create_triggers":
                     trigger_parser = self.create_trigger_parser(row)
                     self.trigger_parsers.append((logging_prefix, trigger_parser))
+                elif row.type == "ignore_row":
+                    self._process_ignore_row(row.sheet_name[0])
                 else:
                     LOGGER.error(f"invalid type: '{row.type}'")
 
@@ -129,6 +136,22 @@ class ContentIndexParser:
             self.template_sheets[sheet_name] = TemplateSheet(
                 sheet.table, row.template_argument_definitions
             )
+
+    def _process_ignore_row(self, sheet_name):
+        # Remove the flow/template definition row for the given name
+        self.flow_definition_rows = [
+            (logging_prefix, row)
+            for logging_prefix, row in self.flow_definition_rows
+            if (row.new_name or row.sheet_name[0]) != sheet_name
+        ]
+        self.template_sheets.pop(sheet_name, None)
+        # Remove campaign/trigger definitions with the given name
+        self.campaign_parsers.pop(sheet_name, None)
+        self.trigger_parsers = [
+            (logging_prefix, trigger_parser)
+            for logging_prefix, trigger_parser in self.trigger_parsers
+            if trigger_parser.sheet_name != sheet_name
+        ]
 
     def _populate_missing_templates(self):
         for logging_prefix, row in self.flow_definition_rows:

--- a/src/rpft/parsers/creation/contentindexparser.py
+++ b/src/rpft/parsers/creation/contentindexparser.py
@@ -138,13 +138,14 @@ class ContentIndexParser:
             )
 
     def _process_ignore_row(self, sheet_name):
-        # Remove the flow/template definition row for the given name
+        # Remove the flow definition row for the given name
         self.flow_definition_rows = [
             (logging_prefix, row)
             for logging_prefix, row in self.flow_definition_rows
             if (row.new_name or row.sheet_name[0]) != sheet_name
         ]
-        self.template_sheets.pop(sheet_name, None)
+        # Template definitions are NOT removed, as their existence
+        # has no effect on the output flows.
         # Remove campaign/trigger definitions with the given name
         self.campaign_parsers.pop(sheet_name, None)
         self.trigger_parsers = [

--- a/tests/test_contentindexparser.py
+++ b/tests/test_contentindexparser.py
@@ -43,11 +43,11 @@ class TestParsing(TestTemplate):
         self.check_basic_template_definition(ci_sheet)
 
     def test_ignore_template_definition(self):
+        # Ensure that ignoring a template row does NOT remove the template
         ci_sheet = (
             "type,sheet_name,data_sheet,data_row_id,new_name,data_model,status\n"
             "template_definition,my_template,,,,,\n"
-            "template_definition,my_template2,,,,,\n"
-            "ignore_row,my_template2,,,,,\n"
+            "ignore_row,my_template,,,,,\n"
         )
         self.check_basic_template_definition(ci_sheet)
 


### PR DESCRIPTION
Defines a new content index row type `ignore_row`. For rows of this type, only the column `sheet_name` is relevant. Ignores/deletes all *previous* template/flow/campaign/trigger definitions that match [sheet_name] in the following way:

- flow: if exists, any create_flow definition row whose `new_name` (or `sheet_name` if not provided) entry is [sheet_name] is ignored
- campaign: if exists, create_campaign whose `new_name` (or `sheet_name` if not provided) is [sheet_name] is ignored
- trigger: if exists, create_trigger whose `sheet_name` is [sheet_name] is ignored

Template definitions are **not** affected by `ignore_row`. The rationale is that often, you use a template to bulk-create a bunch of flows (using data sheets) that are auto-renamed to include the data row ID. You may want to avoid creation of these flows, without deleting the template (in order to create flows using the same template but different data).

Fixes #123 
