### PR TITLE
Upgrade pydantic to v1.10.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rpft"
-version = "1.1.3"
+version = "1.1.3-dev.1"
 description = "Toolkit for using spreadsheets to create and modify RapidPro flows"
 authors = [
     {name = "IDEMS International", email = "communications@idems.international"},
@@ -35,7 +35,7 @@ dependencies = [
     "google-auth-oauthlib~=0.4.4",
     "networkx~=2.5.1",
     "openpyxl~=3.0.7",
-    "pydantic~=1.8.2",
+    "pydantic~=1.10.14",
     "tablib[ods]>=3.1.0",
 ]
 


### PR DESCRIPTION
Required so that the toolkit can be used in projects that use [fastapi](https://fastapi.tiangolo.com/).