### PR TITLE
Airtime related features and minor bugfixes

### DIFF
--- a/src/rpft/parsers/creation/flowparser.py
+++ b/src/rpft/parsers/creation/flowparser.py
@@ -230,7 +230,9 @@ class RowNodeGroup:
             return
 
         # Completed/Expired edge from start_new_flow
-        if isinstance(exit_node, CallWebhookNode) or isinstance(exit_node, TransferAirtimeNode):
+        if isinstance(exit_node, CallWebhookNode) or isinstance(
+            exit_node, TransferAirtimeNode
+        ):
             if condition.value.lower() == "success":
                 exit_node.update_success_exit(destination_uuid)
                 self.has_loose_exit = False

--- a/src/rpft/parsers/creation/flowparser.py
+++ b/src/rpft/parsers/creation/flowparser.py
@@ -13,6 +13,7 @@ from rpft.parsers.creation.flowrowmodel import (
 )
 from rpft.rapidpro.models.actions import (
     AddContactGroupAction,
+    AddContactURNAction,
     Group,
     RemoveContactGroupAction,
     SendMessageAction,
@@ -489,6 +490,11 @@ class FlowParser:
             group = self._get_or_create_group(row.mainarg_groups[0], row.obj_id)
             add_group_action = AddContactGroupAction(groups=[group])
             return add_group_action
+        elif row.type == "add_contact_urn":
+            return AddContactURNAction(
+                path=row.mainarg_value,
+                scheme=row.urn_scheme or 'tel',
+            )
         elif row.type == "remove_from_group":
             group = self._get_or_create_group(row.mainarg_groups[0], row.obj_id)
             remove_group_action = RemoveContactGroupAction(groups=[group])

--- a/src/rpft/parsers/creation/flowparser.py
+++ b/src/rpft/parsers/creation/flowparser.py
@@ -8,8 +8,7 @@ from rpft.parsers.creation.flowrowmodel import (
     Condition,
     Edge,
     FlowRowModel,
-    WebhookError,
-    convert_webhook_headers,
+    list_of_pairs_to_dict,
 )
 from rpft.rapidpro.models.actions import (
     AddContactGroupAction,
@@ -30,10 +29,18 @@ from rpft.rapidpro.models.nodes import (
     EnterFlowNode,
     RandomRouterNode,
     SwitchRouterNode,
+    TransferAirtimeNode,
     )
 from rpft.rapidpro.models.routers import SwitchRouter
 
 LOGGER = get_logger()
+
+
+def string_to_int_or_float(s):
+    try:
+        return int(s)
+    except ValueError:
+        return float(s)
 
 
 class NodeGroup:
@@ -223,7 +230,7 @@ class RowNodeGroup:
             return
 
         # Completed/Expired edge from start_new_flow
-        if isinstance(exit_node, CallWebhookNode):
+        if isinstance(exit_node, CallWebhookNode) or isinstance(exit_node, TransferAirtimeNode):
             if condition.value.lower() == "success":
                 exit_node.update_success_exit(destination_uuid)
                 self.has_loose_exit = False
@@ -231,7 +238,8 @@ class RowNodeGroup:
                 exit_node.update_failure_exit(destination_uuid)
             else:
                 LOGGER.error(
-                    "Condition from call_webhook must be 'Success' or 'Failure'."
+                    "Condition from call_webhook/transfer_airtime must be "
+                    "'Success' or 'Failure'."
                 )
             return
 
@@ -517,6 +525,7 @@ class FlowParser:
             "split_random",
             "start_new_flow",
             "call_webhook",
+            "transfer_airtime",
         ]:
             return None
         else:
@@ -572,15 +581,33 @@ class FlowParser:
             return EnterFlowNode(row.mainarg_flow_name, uuid=node_uuid, ui_pos=ui_pos)
         elif row.type in ["call_webhook"]:
             try:
-                headers = convert_webhook_headers(row.webhook.headers)
-            except WebhookError as e:
-                LOGGER.critical(str(e))
+                headers = list_of_pairs_to_dict(row.webhook.headers)
+            except ValueError as e:
+                LOGGER.critical("webhook.headers: " + str(e))
             return CallWebhookNode(
                 result_name=row.save_name,
                 url=row.webhook.url,
                 method=row.webhook.method,
                 body=row.webhook.body,
                 headers=headers,
+                uuid=node_uuid,
+                ui_pos=ui_pos,
+            )
+        elif row.type in ["transfer_airtime"]:
+            try:
+                airtime_amounts = list_of_pairs_to_dict(row.mainarg_dict)
+            except ValueError as e:
+                LOGGER.critical("airtime_amounts: " + str(e))
+            try:
+                airtime_amounts = {
+                    k : string_to_int_or_float(v)
+                    for k, v in airtime_amounts.items()
+                }
+            except ValueError:
+                LOGGER.critical("airtime_amounts: Current values must be numerical")
+            return TransferAirtimeNode(
+                result_name=row.save_name,
+                amounts=airtime_amounts,
                 uuid=node_uuid,
                 ui_pos=ui_pos,
             )

--- a/src/rpft/parsers/creation/flowrowmodel.py
+++ b/src/rpft/parsers/creation/flowrowmodel.py
@@ -109,6 +109,7 @@ class FlowRowModel(ParserModel):
     audio: str = ""
     video: str = ""
     attachments: List[str] = []  # These come after image/audio/video attachments
+    urn_scheme: str = ""
     obj_name: str = ""  # What is this used for?
     obj_id: str = ""  # This should be a list
     node_name: str = ""  # What is this used for?
@@ -164,6 +165,7 @@ class FlowRowModel(ParserModel):
             "remove_from_group": "mainarg_groups",
             "save_flow_result": "mainarg_value",
             "wait_for_response": "mainarg_none",
+            "add_contact_urn": "mainarg_value",
             "set_contact_language": "mainarg_value",
             "set_contact_name": "mainarg_value",
             "set_contact_status": "mainarg_value",

--- a/src/rpft/parsers/creation/flowrowmodel.py
+++ b/src/rpft/parsers/creation/flowrowmodel.py
@@ -21,11 +21,7 @@ class Webhook(ParserModel):
     body: str = ""
 
 
-class WebhookError(Exception):
-    pass
-
-
-def convert_webhook_headers(headers):
+def list_of_pairs_to_dict(headers):
     # Dict is not yet supported in the row parser,
     # so we need to convert a list of pairs into dict.
     # This function can be removed once dict support is implemented.
@@ -36,14 +32,14 @@ def convert_webhook_headers(headers):
             # Future row parser should return [] instead of [""]
             return {}
         if not all(map(lambda x: type(x) is list and len(x) == 2, headers)):
-            raise WebhookError("Webhook headers must be a list of pairs.")
+            raise ValueError("Value must be a list of pairs.")
         return {k: v for k, v in headers}
     else:
-        raise WebhookError("Webhook headers must be a dict.")
+        raise ValueError("Value must be a dict or list of pairs.")
 
 
-def unconvert_webhook_headers(headers):
-    # Reverse convert_webhook_headers
+def dict_to_list_of_pairs(headers):
+    # Reverse list_of_pairs_to_dict
     # This function can be removed once dict support is implemented.
     if type(headers) is list:
         return headers
@@ -53,7 +49,7 @@ def unconvert_webhook_headers(headers):
             converted.append([k, v])
         return converted
     else:
-        raise WebhookError("Webhook headers must be a list/dict.")
+        raise ValueError("Value must be a list/dict.")
 
 
 class WhatsAppTemplating(ParserModel):
@@ -93,6 +89,7 @@ class FlowRowModel(ParserModel):
     mainarg_value: str = ""
     mainarg_groups: List[str] = []
     mainarg_none: str = ""
+    mainarg_dict: list = []  # encoded as list of pairs
     mainarg_destination_row_ids: List[str] = []
     mainarg_flow_name: str = ""
     mainarg_expression: str = ""
@@ -137,6 +134,7 @@ class FlowRowModel(ParserModel):
             "mainarg_destination_row_ids": "message_text",
             "mainarg_flow_name": "message_text",
             "mainarg_expression": "message_text",
+            "mainarg_dict": "message_text",
             "webhook.body": "message_text",
             # 'mainarg_iterlist' : 'message_text',  # Not supported for export
         }
@@ -173,6 +171,7 @@ class FlowRowModel(ParserModel):
             "split_random": "mainarg_none",
             "go_to": "mainarg_destination_row_ids",
             "call_webhook": "webhook.body",
+            "transfer_airtime": "mainarg_dict",
             "start_new_flow": "mainarg_flow_name",
             "split_by_value": "mainarg_expression",
             "split_by_group": "mainarg_groups",

--- a/src/rpft/rapidpro/models/actions.py
+++ b/src/rpft/rapidpro/models/actions.py
@@ -438,7 +438,7 @@ class SetRunResultAction(Action):
         assert "name" in data
         assert "value" in data
         super()._assign_fields_from_dict(data)
-        if not "category" in data:
+        if "category" not in data:
             self.category = ""
 
     def render(self):

--- a/src/rpft/rapidpro/models/actions.py
+++ b/src/rpft/rapidpro/models/actions.py
@@ -94,6 +94,27 @@ class AddContactURNAction(DefaultRenderedAction):
         }
 
 
+class CallWebhookAction(DefaultRenderedAction):
+    def __init__(self, **kwargs):
+        super().__init__("call_webhook", **kwargs)
+
+    def main_value(self):
+        return self.body
+
+    def get_row_model_fields(self):
+        headers = dict_to_list_of_pairs(self.headers)
+        return {
+            "type": self.type,
+            "webhook": {
+                "body": self.body,
+                "url": self.url,
+                "headers": headers,
+                "method": self.method,
+            },
+            "save_name": self.result_name,
+        }
+
+
 class TransferAirtimeAction(DefaultRenderedAction):
     def __init__(self, **kwargs):
         assert "amounts" in kwargs
@@ -487,7 +508,7 @@ action_map = {
     "add_input_labels": DefaultRenderedAction,
     "call_classifier": DefaultRenderedAction,
     "call_resthook": DefaultRenderedAction,
-    "call_webhook": DefaultRenderedAction,
+    "call_webhook": CallWebhookAction,
     "enter_flow": EnterFlowAction,
     "open_ticket": DefaultRenderedAction,
     "play_audio": DefaultRenderedAction,

--- a/src/rpft/rapidpro/models/actions.py
+++ b/src/rpft/rapidpro/models/actions.py
@@ -38,9 +38,11 @@ class Action:
     def _assign_fields_from_dict(self, data):
         self.__dict__ = copy.deepcopy(data)
 
-    def __init__(self, type):
+    def __init__(self, type, **kwargs):
         self.uuid = generate_new_uuid()
         self.type = type
+        for k, v in kwargs.items():
+            setattr(self, k, v)
 
     def record_global_uuids(self, uuid_dict):
         pass
@@ -68,12 +70,27 @@ class Action:
         raise NotImplementedError
 
 
-class UnclassifiedAction(Action):
+class DefaultRenderedAction(Action):
     def render(self):
         return self.__dict__
 
     def get_row_model_fields(self):
         return NotImplementedError
+
+
+class AddContactURNAction(DefaultRenderedAction):
+    def __init__(self, **kwargs):
+        super().__init__("add_contact_urn", **kwargs)
+
+    def main_value(self):
+        return self.path
+
+    def get_row_model_fields(self):
+        return {
+            "type": self.type,
+            "mainarg_value": self.path,
+            "urn_scheme": self.scheme if self.scheme != "tel" else "",
+        }
 
 
 class WhatsAppMessageTemplating:
@@ -447,18 +464,18 @@ class EnterFlowAction(Action):
 
 action_map = {
     "add_contact_groups": AddContactGroupAction,
-    "add_contact_urn": UnclassifiedAction,
-    "add_input_labels": UnclassifiedAction,
-    "call_classifier": UnclassifiedAction,
-    "call_resthook": UnclassifiedAction,
-    "call_webhook": UnclassifiedAction,
+    "add_contact_urn": AddContactURNAction,
+    "add_input_labels": DefaultRenderedAction,
+    "call_classifier": DefaultRenderedAction,
+    "call_resthook": DefaultRenderedAction,
+    "call_webhook": DefaultRenderedAction,
     "enter_flow": EnterFlowAction,
-    "open_ticket": UnclassifiedAction,
-    "play_audio": UnclassifiedAction,
+    "open_ticket": DefaultRenderedAction,
+    "play_audio": DefaultRenderedAction,
     "remove_contact_groups": RemoveContactGroupAction,
-    "say_msg": UnclassifiedAction,
-    "send_broadcast": UnclassifiedAction,
-    "send_email": UnclassifiedAction,
+    "say_msg": DefaultRenderedAction,
+    "send_broadcast": DefaultRenderedAction,
+    "send_email": DefaultRenderedAction,
     "send_msg": SendMessageAction,
     "set_contact_channel": SetContactPropertyAction,
     "set_contact_field": SetContactFieldAction,
@@ -467,8 +484,8 @@ action_map = {
     "set_contact_status": SetContactPropertyAction,
     "set_contact_timezone": SetContactPropertyAction,
     "set_run_result": SetRunResultAction,
-    "start_session": UnclassifiedAction,
-    "transfer_airtime": UnclassifiedAction,
+    "start_session": DefaultRenderedAction,
+    "transfer_airtime": DefaultRenderedAction,
 }
 
 short_types = {

--- a/src/rpft/rapidpro/models/actions.py
+++ b/src/rpft/rapidpro/models/actions.py
@@ -8,6 +8,7 @@ from rpft.rapidpro.models.common import (
 )
 from rpft.rapidpro.models.exceptions import RapidProActionError
 from rpft.rapidpro.utils import generate_new_uuid
+from rpft.parsers.creation.flowrowmodel import dict_to_list_of_pairs
 
 # TODO: Check enter flow
 # Node classification:
@@ -90,6 +91,24 @@ class AddContactURNAction(DefaultRenderedAction):
             "type": self.type,
             "mainarg_value": self.path,
             "urn_scheme": self.scheme if self.scheme != "tel" else "",
+        }
+
+
+class TransferAirtimeAction(DefaultRenderedAction):
+    def __init__(self, **kwargs):
+        assert "amounts" in kwargs
+        super().__init__("transfer_airtime", **kwargs)
+
+    def main_value(self):
+        return self.amounts
+
+    def get_row_model_fields(self):
+        amounts = {k : str(v) for k, v in self.amounts.items()}
+        amounts = dict_to_list_of_pairs(amounts)
+        return {
+            "type": self.type,
+            "mainarg_dict": amounts,
+            "save_name": self.result_name,
         }
 
 
@@ -485,7 +504,7 @@ action_map = {
     "set_contact_timezone": SetContactPropertyAction,
     "set_run_result": SetRunResultAction,
     "start_session": DefaultRenderedAction,
-    "transfer_airtime": DefaultRenderedAction,
+    "transfer_airtime": TransferAirtimeAction,
 }
 
 short_types = {

--- a/src/rpft/rapidpro/models/common.py
+++ b/src/rpft/rapidpro/models/common.py
@@ -92,7 +92,9 @@ class Group:
     def from_dict(data):
         return Group(**data)
 
-    def __init__(self, name, uuid=None, query=None, status=None, system=None, count=None):
+    def __init__(
+        self, name, uuid=None, query=None, status=None, system=None, count=None
+    ):
         self.name = name
         self.uuid = uuid
         self.query = query

--- a/src/rpft/rapidpro/models/common.py
+++ b/src/rpft/rapidpro/models/common.py
@@ -92,10 +92,13 @@ class Group:
     def from_dict(data):
         return Group(**data)
 
-    def __init__(self, name, uuid=None, query=None):
+    def __init__(self, name, uuid=None, query=None, status=None, system=None, count=None):
         self.name = name
         self.uuid = uuid
         self.query = query
+        self.status = status
+        self.system = system
+        self.count = count
 
     def record_uuid(self, uuid_dict):
         uuid_dict.record_group_uuid(self.name, self.uuid)
@@ -105,6 +108,8 @@ class Group:
 
     def render(self):
         render_dict = {"name": self.name, "uuid": self.uuid}
-        if self.query:
-            render_dict["query"] = self.query
+        for attribute in ["query", "status", "system", "count"]:
+            value = getattr(self, attribute)
+            if value is not None:
+                render_dict[attribute] = value
         return render_dict

--- a/src/rpft/rapidpro/models/nodes.py
+++ b/src/rpft/rapidpro/models/nodes.py
@@ -4,8 +4,6 @@ from abc import ABC, abstractmethod
 from rpft.parsers.creation.flowrowmodel import (
     Edge,
     FlowRowModel,
-    Webhook,
-    dict_to_list_of_pairs,
 )
 from rpft.rapidpro.models.actions import (
     Action,

--- a/src/rpft/rapidpro/models/nodes.py
+++ b/src/rpft/rapidpro/models/nodes.py
@@ -8,7 +8,7 @@ from rpft.parsers.creation.flowrowmodel import (
     dict_to_list_of_pairs,
 )
 from rpft.rapidpro.models.actions import Action, EnterFlowAction, TransferAirtimeAction
-from rpft.rapidpro.models.common import Exit, mangle_string
+from rpft.rapidpro.models.common import Exit, generate_field_key, mangle_string
 from rpft.rapidpro.models.routers import RandomRouter, SwitchRouter
 from rpft.rapidpro.utils import generate_new_uuid
 
@@ -678,13 +678,14 @@ class TransferAirtimeNode(RouterNode):
         if router:
             self.router = router
         else:
+            result_field = generate_field_key(result_name)
             self.router = SwitchRouter(
-                operand=f"@results.{result_name}",
+                operand=f"@results.{result_field}",
             )
             self.router.default_category.update_name("Failure")
 
             self.add_choice(
-                comparison_variable=f"@results.{result_name}",
+                comparison_variable=f"@results.{result_field}",
                 comparison_type="has_category",
                 comparison_arguments=["Success"],
                 category_name="Success",

--- a/src/rpft/rapidpro/models/routers.py
+++ b/src/rpft/rapidpro/models/routers.py
@@ -110,16 +110,16 @@ class SwitchRouter(BaseRouter):
         self.wait_timeout = wait_timeout
 
         self.has_explicit_default_category = False
-        if categories and default_category:
-            self.categories = categories
+
+        if default_category:
             self.default_category = default_category
             # Indicates that a default category has been added by the user
             self.has_explicit_default_category = True
         else:
-            self.categories = []
             # Add an implicit default category
             category = RouterCategory("Other", None)
             self.default_category = category
+        self.categories = categories or []
 
         self.has_explicit_no_response_category = False
         if self.wait_timeout:

--- a/src/rpft/rapidpro/models/routers.py
+++ b/src/rpft/rapidpro/models/routers.py
@@ -66,6 +66,12 @@ class BaseRouter:
     def get_exits(self):
         return [c.get_exit() for c in self.get_categories()]
 
+    def record_global_uuids(self, uuid_dict):
+        pass
+
+    def assign_global_uuids(self, uuid_dict):
+        pass
+
     def get_categories(self):
         # TODO: Remove this and have the default category included in the list for the
         # SwitchRouter

--- a/tests/input/no_switch_nodes.csv
+++ b/tests/input/no_switch_nodes.csv
@@ -9,3 +9,4 @@
 8,"save_flow_result",7,,,,,"result name","result value","my_result_cat",,,,,,,,,,,,,,,,"E","88c593b0-22ba-4a36-8f6a-ffe4e41818d1",,"execute_actions","280;900"
 9,"set_contact_language",8,,,,,,"eng",,,,,,,,,,,,,,,,,,"711ea340-dc20-4471-a0e4-6af2c4a278b9",,"execute_actions","280;1020"
 10,"set_contact_name",9,,,,,,"John Doe",,,,,,,,,,,,,,,,,,"711ea340-dc20-4471-a0e4-6af2c4a278b9",,"execute_actions","280;1020"
+11,"add_contact_urn",10,,,,,,"@results.internation_phone_number",,,,,,,,,,,,,,,,,,"768afc12-93e8-4cf8-9cdc-c92cce36c365",,,

--- a/tests/input/no_switch_nodes_without_row_ids.csv
+++ b/tests/input/no_switch_nodes_without_row_ids.csv
@@ -9,3 +9,4 @@
 ,"save_flow_result",,,,,,"result name","result value",,,,,,,,,,,,,,,,"E","88c593b0-22ba-4a36-8f6a-ffe4e41818d1",,"execute_actions","280;900"
 ,"set_contact_language",,,,,,,"eng",,,,,,,,,,,,,,,,,"711ea340-dc20-4471-a0e4-6af2c4a278b9",,"execute_actions","280;1020"
 ,"set_contact_name",,,,,,,"John Doe",,,,,,,,,,,,,,,,,"711ea340-dc20-4471-a0e4-6af2c4a278b9",,"execute_actions","280;1020"
+,"add_contact_urn",,,,,,,"@results.internation_phone_number",,,,,,,,,,,,,,,,,"768afc12-93e8-4cf8-9cdc-c92cce36c365",,,

--- a/tests/input/switch_nodes.csv
+++ b/tests/input/switch_nodes.csv
@@ -1,18 +1,21 @@
-"row_id","type","from","condition","condition_var","condition_type","condition_name","save_name","message_text","choices.1","choices.2","choices.3","choices.4","choices.5","choices.6","choices.7","choices.8","choices.9","choices.10","image","audio","video","obj_id","_nodeId","no_response","_ui_type","_ui_position"
-1,"wait_for_response","start",,,,,"Result_wfr",,,,,,,,,,,,,,,,"bb408455-d8f5-4377-a901-717ade84688b",,"wait_for_response","340;0"
-2,"start_new_flow","1;1","a;b",,"has_any_word;has_any_word","A;B",,"loop_and_multiple_conditions",,,,,,,,,,,,,,"c1a32f07-ff0f-4b8b-a700-360c13f53914","3ecfb56f-627b-4afe-8448-a14eaccfbe0e",,"split_by_subflow","360;180"
-3,"split_by_value","2","completed",,,,,"expression",,,,,,,,,,,,,,,"1bf341f3-e043-4024-88bd-271bb61f6f1e",,"split_by_expression","400;360"
-4,"split_by_value","3","a","expression","has_any_word","A",,"@contact.name",,,,,,,,,,,,,,,"7dca0b72-ec99-49c9-95ae-681bf9e65cba",,"split_by_contact_field","400;480"
-5,"split_by_value","4","a","@contact.name","has_any_word","A",,"@results.result_wfr",,,,,,,,,,,,,,,"95f465cd-6794-4ff4-b926-e94afd341ebf",,"split_by_run_result","400;620"
-6,"split_by_group","5","a","@results.result_wfr","has_any_word","A",,"test group",,,,,,,,,,,,,,"8224bfe2-acec-434f-bc7c-14c584fc4bc8","bac467c9-e699-4211-bc70-3440414fd301",,"split_by_groups","360;740"
-7,"wait_for_response","6","test group",,,,"Result",,,,,,,,,,,,,,,,"deda75fc-d136-4666-b7c5-f8a23b4a2cd8",300,"wait_for_response","380;880"
-8,"split_random","7","a",,"has_any_word","A",,,,,,,,,,,,,,,,,"37538d9a-7920-474e-aeea-69037a39f111",,"split_by_random","280;1060"
-9,"send_message","8","1",,,,,"b1",,,,,,,,,,,,,,,"8e97560c-a019-44bd-b65d-ae9e025e97cc",,"execute_actions","120;1180"
-10,"send_message","8;8","2;3",,,,,"b2 b3",,,,,,,,,,,,,,,"224f6caa-fd25-47d3-96a9-3d43506b7878",,"execute_actions","340;1280"
-11,"send_message","7",,,,,,"other option message",,,,,,,,,,,,,,,"acf35dbd-e737-469d-95c3-798544bfbfe5",,"execute_actions","600;1060"
-12,"send_message","7","No Response",,,,,"no response message",,,,,,,,,,,,,,,"ba443bbb-00a7-4bdd-8de1-d783ade863d5",,"execute_actions","840;1060"
-13,"wait_for_response","12",,,,,,,,,,,,,,,,,,,,,"e0a3e4e8-66bf-41b6-9a4e-a9d473e6d3b7",84600,"wait_for_response","840;1200"
-14,"send_message","2","expired",,,,,"expired flow",,,,,,,,,,,,,,,"5beeda91-eeca-4287-a48e-7eebf5f3a7e7",,"execute_actions","740;300"
-15,"transfer_airtime","14",,,,,"transaction_id","RWF;500|USD;0.5",,,,,,,,,,,,,,,"fe6e3a99-4e38-47eb-94e9-e63ecf45750b",,,
-16,"send_message","15","Success","@results.transaction_id","has_category","Success",,"Transaction Success",,,,,,,,,,,,,,,"123eda91-eeca-4287-a48e-7eebf5f3a7e7",,,
-17,"send_message","15",,,,,,"Transaction Failure",,,,,,,,,,,,,,,"f411da91-eeca-4287-a48e-7eebf5f3a7e7",,,
+"row_id","type","from","condition","condition_var","condition_type","condition_name","save_name","message_text","webhook.url","webhook.method","webhook.headers","choices.1","choices.2","choices.3","choices.4","choices.5","choices.6","choices.7","choices.8","choices.9","choices.10","image","audio","video","obj_id","_nodeId","no_response","_ui_type","_ui_position"
+1,"wait_for_response","start",,,,,"Result_wfr",,,,,,,,,,,,,,,,,,,"bb408455-d8f5-4377-a901-717ade84688b",,"wait_for_response","340;0"
+2,"start_new_flow","1;1","a;b",,"has_any_word;has_any_word","A;B",,"loop_and_multiple_conditions",,,,,,,,,,,,,,,,,"c1a32f07-ff0f-4b8b-a700-360c13f53914","3ecfb56f-627b-4afe-8448-a14eaccfbe0e",,"split_by_subflow","360;180"
+3,"split_by_value","2","completed",,,,,"expression",,,,,,,,,,,,,,,,,,"1bf341f3-e043-4024-88bd-271bb61f6f1e",,"split_by_expression","400;360"
+4,"split_by_value","3","a","expression","has_any_word","A",,"@contact.name",,,,,,,,,,,,,,,,,,"7dca0b72-ec99-49c9-95ae-681bf9e65cba",,"split_by_contact_field","400;480"
+5,"split_by_value","4","a","@contact.name","has_any_word","A",,"@results.result_wfr",,,,,,,,,,,,,,,,,,"95f465cd-6794-4ff4-b926-e94afd341ebf",,"split_by_run_result","400;620"
+6,"split_by_group","5","a","@results.result_wfr","has_any_word","A",,"test group",,,,,,,,,,,,,,,,,"8224bfe2-acec-434f-bc7c-14c584fc4bc8","bac467c9-e699-4211-bc70-3440414fd301",,"split_by_groups","360;740"
+7,"wait_for_response","6","test group",,,,"Result",,,,,,,,,,,,,,,,,,,"deda75fc-d136-4666-b7c5-f8a23b4a2cd8",300,"wait_for_response","380;880"
+8,"split_random","7","a",,"has_any_word","A",,,,,,,,,,,,,,,,,,,,"37538d9a-7920-474e-aeea-69037a39f111",,"split_by_random","280;1060"
+9,"send_message","8","1",,,,,"b1",,,,,,,,,,,,,,,,,,"8e97560c-a019-44bd-b65d-ae9e025e97cc",,"execute_actions","120;1180"
+10,"send_message","8;8","2;3",,,,,"b2 b3",,,,,,,,,,,,,,,,,,"224f6caa-fd25-47d3-96a9-3d43506b7878",,"execute_actions","340;1280"
+11,"send_message","7",,,,,,"other option message",,,,,,,,,,,,,,,,,,"acf35dbd-e737-469d-95c3-798544bfbfe5",,"execute_actions","600;1060"
+12,"send_message","7","No Response",,,,,"no response message",,,,,,,,,,,,,,,,,,"ba443bbb-00a7-4bdd-8de1-d783ade863d5",,"execute_actions","840;1060"
+13,"wait_for_response","12",,,,,,,,,,,,,,,,,,,,,,,,"e0a3e4e8-66bf-41b6-9a4e-a9d473e6d3b7",84600,"wait_for_response","840;1200"
+14,"send_message","2","expired",,,,,"expired flow",,,,,,,,,,,,,,,,,,"5beeda91-eeca-4287-a48e-7eebf5f3a7e7",,"execute_actions","740;300"
+15,"transfer_airtime","14",,,,,"transaction_id","RWF;500|USD;0.5",,,,,,,,,,,,,,,,,,"fe6e3a99-4e38-47eb-94e9-e63ecf45750b",,,
+16,"send_message","15","Success","@results.transaction_id","has_category","Success",,"Transaction Success",,,,,,,,,,,,,,,,,,"123eda91-eeca-4287-a48e-7eebf5f3a7e7",,,
+17,"send_message","15",,,,,,"Transaction Failure",,,,,,,,,,,,,,,,,,"f411da91-eeca-4287-a48e-7eebf5f3a7e7",,,
+18,"call_webhook","17",,,,,"webhook_result","Webhook Body","http://localhost:49998/?cmd=success","GET","Authorization;Token AAFFZZHH|",,,,,,,,,,,,,,,"2aa3a76b-b884-4748-aa5e-c691e25f51de",,,
+19,"send_message","18","Success","@results.webhook_result.category","has_only_text","Success",,"Webhook Success",,,,,,,,,,,,,,,,,,"3b001231-eeca-4287-a48e-7eebf5f3a7e7",,,
+20,"send_message","18",,,,,,"Webhook Failure",,,,,,,,,,,,,,,,,,"3b00f411-eeca-4287-a48e-7eebf5f3a7e7",,,

--- a/tests/input/switch_nodes.csv
+++ b/tests/input/switch_nodes.csv
@@ -13,3 +13,6 @@
 12,"send_message","7","No Response",,,,,"no response message",,,,,,,,,,,,,,,"ba443bbb-00a7-4bdd-8de1-d783ade863d5",,"execute_actions","840;1060"
 13,"wait_for_response","12",,,,,,,,,,,,,,,,,,,,,"e0a3e4e8-66bf-41b6-9a4e-a9d473e6d3b7",84600,"wait_for_response","840;1200"
 14,"send_message","2","expired",,,,,"expired flow",,,,,,,,,,,,,,,"5beeda91-eeca-4287-a48e-7eebf5f3a7e7",,"execute_actions","740;300"
+15,"transfer_airtime","14",,,,,"transaction_id","RWF;500|USD;0.5",,,,,,,,,,,,,,,"fe6e3a99-4e38-47eb-94e9-e63ecf45750b",,,
+16,"send_message","15","Success","@results.transaction_id","has_category","Success",,"Transaction Success",,,,,,,,,,,,,,,"123eda91-eeca-4287-a48e-7eebf5f3a7e7",,,
+17,"send_message","15",,,,,,"Transaction Failure",,,,,,,,,,,,,,,"f411da91-eeca-4287-a48e-7eebf5f3a7e7",,,

--- a/tests/output/all_test_flows.json
+++ b/tests/output/all_test_flows.json
@@ -155,6 +155,23 @@
           "exits": [
             {
               "uuid": "6d7c4c09-366c-41cf-a0ef-ce0ec45c8f4a",
+              "destination_uuid": "768afc12-93e8-4cf8-9cdc-c92cce36c365"
+            }
+          ]
+        },
+        {
+          "uuid": "768afc12-93e8-4cf8-9cdc-c92cce36c365",
+          "actions": [
+            {
+                "type": "add_contact_urn",
+                "uuid": "5ae58ed1-e130-4841-a459-0cc7aa76b5be",
+                "scheme": "tel",
+                "path": "@results.internation_phone_number"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "51548997-3f36-487d-9498-b48e33907b49",
               "destination_uuid": null
             }
           ]

--- a/tests/output/all_test_flows.json
+++ b/tests/output/all_test_flows.json
@@ -932,6 +932,93 @@
           "exits": [
             {
               "uuid": "93885cbc-0131-4ea1-82d7-0cd5f57ddb63",
+              "destination_uuid": "fe6e3a99-4e38-47eb-94e9-e63ecf45750b"
+            }
+          ]
+        },
+        {
+          "uuid": "fe6e3a99-4e38-47eb-94e9-e63ecf45750b",
+          "actions": [
+            {
+              "uuid": "373e6372-870b-4612-a006-c8d33f57c04d",
+              "type": "transfer_airtime",
+              "amounts": {
+                "RWF": 500,
+                "USD": 0.5
+              },
+              "result_name": "transaction id"
+            }
+          ],
+          "router": {
+            "type": "switch",
+            "operand": "@results.transaction_id",
+            "cases": [
+              {
+                "uuid": "87cea0a5-f3ab-4c8f-b475-44c9a711d92e",
+                "type": "has_category",
+                "arguments": [
+                  "Success"
+                ],
+                "category_uuid": "6bf4209a-7f74-4ebc-a4b3-e87b00d88e99"
+              }
+            ],
+            "categories": [
+              {
+                "uuid": "6bf4209a-7f74-4ebc-a4b3-e87b00d88e99",
+                "name": "Success",
+                "exit_uuid": "603e1ac4-4930-4820-8883-a34e34c0ea0e"
+              },
+              {
+                "uuid": "b3675266-b7cb-44e8-af4c-4527ec84f6f1",
+                "name": "Failure",
+                "exit_uuid": "2a724cc1-6e92-44b7-b8d7-cd42cf96b9af"
+              }
+            ],
+            "default_category_uuid": "b3675266-b7cb-44e8-af4c-4527ec84f6f1"
+          },
+          "exits": [
+            {
+              "uuid": "603e1ac4-4930-4820-8883-a34e34c0ea0e",
+              "destination_uuid": "123eda91-eeca-4287-a48e-7eebf5f3a7e7"
+            },
+            {
+              "uuid": "2a724cc1-6e92-44b7-b8d7-cd42cf96b9af",
+              "destination_uuid": "f411da91-eeca-4287-a48e-7eebf5f3a7e7"
+            }
+          ]
+        },
+        {
+          "uuid": "123eda91-eeca-4287-a48e-7eebf5f3a7e7",
+          "actions": [
+            {
+              "attachments": [],
+              "text": "Transaction Success",
+              "type": "send_msg",
+              "quick_replies": [],
+              "uuid": "c1347bff-9307-4c95-a0b2-9d4dbd290069"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "93885cbc-0131-4ea1-82d7-0cd5f57ddb63",
+              "destination_uuid": null
+            }
+          ]
+        },
+        {
+          "uuid": "f411da91-eeca-4287-a48e-7eebf5f3a7e7",
+          "actions": [
+            {
+              "attachments": [],
+              "text": "Transaction Failure",
+              "type": "send_msg",
+              "quick_replies": [],
+              "uuid": "c1347bff-9307-4c95-a0b2-9d4dbd290069"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "93885cbc-0131-4ea1-82d7-0cd5f57ddb63",
               "destination_uuid": null
             }
           ]

--- a/tests/output/all_test_flows.json
+++ b/tests/output/all_test_flows.json
@@ -1019,6 +1019,93 @@
           "exits": [
             {
               "uuid": "93885cbc-0131-4ea1-82d7-0cd5f57ddb63",
+              "destination_uuid": "2aa3a76b-b884-4748-aa5e-c691e25f51de"
+            }
+          ]
+        },
+        {
+          "uuid": "2aa3a76b-b884-4748-aa5e-c691e25f51de",
+          "actions": [
+            {
+              "type": "call_webhook",
+              "body": "Webhook Body",
+              "method": "GET",
+              "url": "http://localhost:49998/?cmd=success",
+              "headers": {"Authorization": "Token AAFFZZHH"},
+              "result_name": "webhook_result",
+              "uuid": "c9e5be7d-f9eb-4992-aadb-7f82463e2037"
+            }
+          ],
+          "router": {
+            "type": "switch",
+            "operand": "@results.webhook_result.category",
+            "cases": [
+              {
+                "uuid": "257696c8-b22a-4633-8cca-b25e7c5390c8",
+                "type": "has_only_text",
+                "category_uuid": "4c646421-28b4-43af-a8d9-3c9bd7d5a4ad",
+                "arguments": [
+                  "Success"
+                ]
+              }
+            ],
+            "categories": [
+              {
+                "uuid": "4c646421-28b4-43af-a8d9-3c9bd7d5a4ad",
+                "name": "Success",
+                "exit_uuid": "f02d34ec-1d3e-4ca2-8528-18188079e343"
+              },
+              {
+                "uuid": "a8c51fc8-f893-44ba-95e3-59c2f0db6778",
+                "name": "Failure",
+                "exit_uuid": "97fd85ab-8c21-4532-bc3b-d51fdd08e7cc"
+              }
+            ],
+            "default_category_uuid": "a8c51fc8-f893-44ba-95e3-59c2f0db6778"
+          },
+          "exits": [
+            {
+              "destination_uuid": "3b001231-eeca-4287-a48e-7eebf5f3a7e7",
+              "uuid": "f02d34ec-1d3e-4ca2-8528-18188079e343"
+            },
+            {
+              "destination_uuid": "3b00f411-eeca-4287-a48e-7eebf5f3a7e7",
+              "uuid": "97fd85ab-8c21-4532-bc3b-d51fdd08e7cc"
+            }
+          ]
+        },
+        {
+          "uuid": "3b001231-eeca-4287-a48e-7eebf5f3a7e7",
+          "actions": [
+            {
+              "attachments": [],
+              "text": "Webhook Success",
+              "type": "send_msg",
+              "quick_replies": [],
+              "uuid": "c1347bff-9307-4c95-a0b2-9d4dbd290069"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "93885cbc-0131-4ea1-82d7-0cd5f57ddb63",
+              "destination_uuid": null
+            }
+          ]
+        },
+        {
+          "uuid": "3b00f411-eeca-4287-a48e-7eebf5f3a7e7",
+          "actions": [
+            {
+              "attachments": [],
+              "text": "Webhook Failure",
+              "type": "send_msg",
+              "quick_replies": [],
+              "uuid": "c1347bff-9307-4c95-a0b2-9d4dbd290069"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "93885cbc-0131-4ea1-82d7-0cd5f57ddb63",
               "destination_uuid": null
             }
           ]

--- a/tests/test_flowparser.py
+++ b/tests/test_flowparser.py
@@ -1131,7 +1131,10 @@ class TestFlowParser(unittest.TestCase):
         )
 
     def test_switch_nodes(self):
-        context = Context(inputs=["b", "expired"])
+        context = Context(inputs=["b", "expired", "Success"])
+        self.run_example("input/switch_nodes.csv", "switch_nodes", context)
+
+        context = Context(inputs=["b", "expired", "Failure", "Success"])
         self.run_example("input/switch_nodes.csv", "switch_nodes", context)
 
         context = Context(

--- a/tests/test_flowparser.py
+++ b/tests/test_flowparser.py
@@ -163,16 +163,16 @@ class TestParsing(unittest.TestCase):
         # Check that node UUIDs are maintained
         nodes = render_output["nodes"]
         actual_node_uuids = [node["uuid"] for node in nodes]
-        expected_node_uuids = [row.node_uuid for row in self.rows][
-            3:-1
-        ]  # The first 4 and last 2 rows are actions joined into a single node.
+        all_node_uuids = [row.node_uuid for row in self.rows]
+        # Rows 0,1,2,3 and rows -3,-2 are actions joined into a single node.
+        expected_node_uuids = all_node_uuids[3:-2] + all_node_uuids[-1:]
         self.assertEqual(expected_node_uuids, actual_node_uuids)
 
         self.assertEqual(render_output["name"], "no_switch_node")
         self.assertEqual(render_output["type"], "messaging")
         self.assertEqual(render_output["language"], "eng")
 
-        self.assertEqual(len(render_output["nodes"]), 6)
+        self.assertEqual(len(render_output["nodes"]), 7)
 
         node_0 = render_output["nodes"][0]
         node_0_actions = node_0["actions"]
@@ -251,13 +251,16 @@ class TestParsing(unittest.TestCase):
 
         node_5 = render_output["nodes"][5]
         self.assertEqual(node_4["exits"][0]["destination_uuid"], node_5["uuid"])
-        self.assertIsNone(node_5["exits"][0]["destination_uuid"])
         node_5_actions = node_5["actions"]
         self.assertEqual(len(node_5_actions), 2)
         self.assertEqual(node_5_actions[0]["type"], "set_contact_language")
         self.assertEqual(node_5_actions[0]["language"], "eng")
         self.assertEqual(node_5_actions[1]["type"], "set_contact_name")
         self.assertEqual(node_5_actions[1]["name"], "John Doe")
+
+        node_6 = render_output["nodes"][6]
+        self.assertEqual(node_5["exits"][0]["destination_uuid"], node_6["uuid"])
+        self.assertIsNone(node_6["exits"][0]["destination_uuid"])
 
         # Check UI positions/types of the first two nodes
         render_ui = render_output["_ui"]["nodes"]

--- a/tests/test_flowparser.py
+++ b/tests/test_flowparser.py
@@ -285,7 +285,7 @@ class TestParsing(unittest.TestCase):
         self.assertEqual(expected_node_uuids, actual_node_uuids)
 
         # Check that No Response category is created even if not connected
-        last_wait_node = nodes[-2]
+        last_wait_node = nodes[12]
         self.assertEqual(
             "No Response", last_wait_node["router"]["categories"][-1]["name"]
         )
@@ -312,8 +312,8 @@ class TestParsing(unittest.TestCase):
         self.assertIn(f_uuid(0), render_ui)
         self.assertEqual((340, 0), f_uipos(0))
         self.assertEqual((360, 180), f_uipos(1))
-        self.assertEqual((840, 1200), f_uipos(-2))
-        self.assertEqual((740, 300), f_uipos(-1))
+        self.assertEqual((840, 1200), f_uipos(12))
+        self.assertEqual((740, 300), f_uipos(13))
         self.assertEqual("wait_for_response", f_uitype(0))
         self.assertEqual("split_by_subflow", f_uitype(1))
         self.assertEqual("split_by_expression", f_uitype(2))
@@ -324,7 +324,7 @@ class TestParsing(unittest.TestCase):
         self.assertEqual("split_by_random", f_uitype(7))
         self.assertEqual("execute_actions", f_uitype(8))
         self.assertEqual("execute_actions", f_uitype(9))
-        self.assertEqual("wait_for_response", f_uitype(-2))
+        self.assertEqual("wait_for_response", f_uitype(12))
 
         # Ensure that wait_for_response cases are working as intended
         node6 = render_output["nodes"][6]

--- a/tests/test_flowparser_reverse.py
+++ b/tests/test_flowparser_reverse.py
@@ -31,10 +31,13 @@ class TestFlowParserReverse(unittest.TestCase):
             # the other of these fields may be removed as well.
             model_dict.pop(field)
             model_exp_dict.pop(field)
-        # TODO: We have trailing '' quick replies here.
+        # TODO: We have trailing '' quick replies and webhook.headers here.
         # They get removed in the conversion process, but probably the RowParser
         # should already take care of them
         model_exp_dict["choices"] = [qr for qr in model_exp_dict["choices"] if qr]
+        model_exp_dict["webhook"]["headers"] = [
+            header for header in model_exp_dict["webhook"]["headers"] if header
+        ]
         self.assertEqual(model_dict, model_exp_dict)
 
     def run_example(self, filename, flow_name):

--- a/tests/test_to_row_model.py
+++ b/tests/test_to_row_model.py
@@ -150,6 +150,7 @@ class TestFlowContainer(TestToRowModels):
             edges=[{"from_": "start"}],
             type="call_webhook",
             webhook=Webhook(headers=headers, **webhook_data),
+            save_name="result name",
         )
         node = CallWebhookNode(
             result_name="result name", headers=headers_dict, **webhook_data

--- a/tests/test_to_row_model.py
+++ b/tests/test_to_row_model.py
@@ -7,7 +7,7 @@ from rpft.parsers.creation.flowrowmodel import (
     Edge,
     FlowRowModel,
     Webhook,
-    convert_webhook_headers
+    list_of_pairs_to_dict
 )
 from rpft.rapidpro.models.actions import (
     AddContactGroupAction,
@@ -144,7 +144,7 @@ class TestFlowContainer(TestToRowModels):
             "body": "payload",
         }
         headers = [["header1", "value1"], ["header2", "value2"]]
-        headers_dict = convert_webhook_headers(headers)
+        headers_dict = list_of_pairs_to_dict(headers)
         row_data = FlowRowModel(
             row_id="webhook.the_url",
             edges=[{"from_": "start"}],

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -91,9 +91,8 @@ def find_destination_uuid(current_node, context):
             # Get value of the operand
             if router["operand"] == "@contact.groups":
                 operand = context.group_names
-            elif router["operand"] in ["@input.text", "@child.run.status"] or re.match(
-                r"@results\..*\.category", router["operand"]
-            ):
+            elif router["operand"] == "@input.text" or current_node["actions"]:
+                # Actions implies CallWebhook, TransferAirtime or EnterFlow
                 operand = context.inputs.pop(0)
             elif router["operand"] in context.variables:
                 operand = context.variables[router["operand"]]
@@ -127,7 +126,11 @@ def find_destination_uuid(current_node, context):
                         if case["arguments"][0].lower() in operand.lower():
                             category_uuid = case["category_uuid"]
                             break
-                    elif case["type"] == "has_only_text":  # case sensitive
+                    elif (
+                        case["type"] == "has_only_text"
+                        or case["type"] == "has_category"
+                    ):
+                        # These are case sensitive
                         if case["arguments"][0] == operand:
                             category_uuid = case["category_uuid"]
                             break


### PR DESCRIPTION
- Support extra fields for groups so that flows from newer RapidPro versions can be loaded and converted.
- Support add_contact_urn and transfer_airtime row type
- flows_to_sheets: Support call_webhook and the above two new row types
- Bugfix: When loading flows from JSON, WaitForResponse nodes with a single (default) category would have their category replaced and lose the connection to the next node in the process.