### PR TITLE
Trim whitespace from plain strings in CellParser

### DIFF
--- a/tests/input/no_switch_nodes.csv
+++ b/tests/input/no_switch_nodes.csv
@@ -3,7 +3,7 @@
 2,"send_message",1,,,,,,"message with image",,,,,,,,,,,,"image u",,,,,"A","769804d7-7343-4e78-97f3-7a113e8222d2",,"execute_actions","280;73"
 3,"send_message",2,,,,,,"message with audio",,,,,,,,,,,,,"audio u",,,,"A","769804d7-7343-4e78-97f3-7a113e8222d2",,"execute_actions","280;73"
 4,"send_message",3,,,,,,"message with video",,,,,,,,,,,,,,"video u",,,"A","769804d7-7343-4e78-97f3-7a113e8222d2",,"execute_actions","280;73"
-5,"save_value",4,,,,,"test variable","test value ",,,,,,,,,,,,,,,,,"B","f33d09fc-ead6-4db4-b2a7-e5566c16f4cb",,"execute_actions","280;600"
+5,"save_value",4,,,,,"test variable","test value",,,,,,,,,,,,,,,,,"B","f33d09fc-ead6-4db4-b2a7-e5566c16f4cb",,"execute_actions","280;600"
 6,"add_to_group",5,,,,,,"test group",,,,,,,,,,,,,,,"A","8224bfe2-acec-434f-bc7c-14c584fc4bc8","C","db66d0df-0906-45ca-8378-cf1d39ce0281",,"execute_actions","280;700"
 7,"remove_from_group",6,,,,,,"test group",,,,,,,,,,,,,,,"A","8224bfe2-acec-434f-bc7c-14c584fc4bc8","D","21be0fc2-f28c-4ad0-8c02-4afd63ad31ab",,"execute_actions","280;800"
 8,"save_flow_result",7,,,,,"result name","result value","my_result_cat",,,,,,,,,,,,,,,,"E","88c593b0-22ba-4a36-8f6a-ffe4e41818d1",,"execute_actions","280;900"

--- a/tests/test_cellparser.py
+++ b/tests/test_cellparser.py
@@ -114,9 +114,19 @@ class TestCellParser(unittest.TestCase):
     def setUp(self):
         self.parser = CellParser()
 
+    def test_strings_without_templates_are_not_changed(self):
+        self.assertEqual(
+            CellParser().parse_as_string("plain string"),
+            "plain string",
+        )
+
+    def test_strings_are_trimmed(self):
+        self.assertEqual(
+            CellParser().parse_as_string(" plain string "),
+            "plain string",
+        )
+
     def test_parse_as_string(self):
-        out = self.parser.parse_as_string("plain string")
-        self.assertEqual(out, "plain string")
         out = self.parser.parse_as_string("{{var}} :)", context={"var": 15})
         self.assertEqual(out, "15 :)")
 

--- a/tests/test_cellparser.py
+++ b/tests/test_cellparser.py
@@ -125,19 +125,34 @@ class TestCellParser(unittest.TestCase):
             CellParser().parse_as_string(" plain string "),
             "plain string",
         )
-
-    def test_parse_as_string(self):
-        out = self.parser.parse_as_string("{{var}} :)", context={"var": 15})
-        self.assertEqual(out, "15 :)")
-
-        instance = OuterModel(strings=["a", "b"], inner=InnerModel(str_field="xyz"))
-        context = {"instance": instance}
-        out = self.parser.parse_as_string("{{instance.strings[1]}}", context=context)
-        self.assertEqual(out, "b")
-        out = self.parser.parse_as_string(
-            "{{instance.inner.str_field}}", context=context
+        self.assertEqual(
+            CellParser().parse_as_string(" {{var}} string ", context={"var": "abc"}),
+            "abc string",
         )
-        self.assertEqual(out, "xyz")
+
+    def test_template_variable_substitution(self):
+        self.assertEqual(
+            CellParser().parse_as_string("{{var}} :)", context={"var": 15}),
+            "15 :)",
+        )
+
+    def test_template_variable_substitution_of_nested_objects(self):
+        context = {
+            "instance": OuterModel(
+                strings=["a", "b"],
+                inner=InnerModel(str_field="xyz"),
+            )
+        }
+        parser = CellParser()
+
+        self.assertEqual(
+            parser.parse_as_string("{{instance.strings[1]}}", context=context),
+            "b",
+        )
+        self.assertEqual(
+            parser.parse_as_string("{{instance.inner.str_field}}", context=context),
+            "xyz",
+        )
 
     def test_parse(self):
         out = self.parser.parse("a;b;c")

--- a/tests/test_flowparser.py
+++ b/tests/test_flowparser.py
@@ -199,7 +199,7 @@ class TestParsing(TestCase):
         self.assertEqual(node_1["actions"][0]["type"], "set_contact_field")
         self.assertEqual(node_1["actions"][0]["field"]["key"], "test_variable")
         self.assertEqual(node_1["actions"][0]["field"]["name"], "test variable")
-        self.assertEqual(node_1["actions"][0]["value"], "test value ")
+        self.assertEqual(node_1["actions"][0]["value"], "test value")
 
         node_2 = nodes[2]
         self.assertEqual(node_1["exits"][0]["destination_uuid"], node_2["uuid"])


### PR DESCRIPTION
The CellParser trims whitespace from the beginning and end of templated cell values, but not for non-templated values. There doesn't seem to be a good reason for this, so this change makes the behaviour consistent.