### PR TITLE
Raise exception if reserved contact field keys are used

### DIFF
--- a/src/rpft/rapidpro/models/common.py
+++ b/src/rpft/rapidpro/models/common.py
@@ -4,6 +4,7 @@ from rpft.rapidpro.models.exceptions import RapidProActionError
 from rpft.rapidpro.utils import generate_new_uuid
 
 
+FIELD_KEY_MAX_LENGTH = 36
 RESERVED_FIELD_KEYS = [
     "created_by",
     "created_on",
@@ -91,19 +92,21 @@ class FlowReference:
 
 
 def generate_field_key(field_name):
-    field_key = field_name.strip().lower().replace(" ", "_")
+    key = field_name.strip().lower().replace(" ", "_")
 
-    if not len(field_key) <= 36:
+    if len(key) > FIELD_KEY_MAX_LENGTH:
         raise RapidProActionError(
-            "Contact field keys should be no longer than 36 characters."
+            "Contact field key length limit exceeded",
+            {"length": len(key), "limit": FIELD_KEY_MAX_LENGTH, "key": key}
         )
 
-    if not re.search("[A-Za-z]", field_key):
+    if not re.search("[A-Za-z]", key):
         raise RapidProActionError(
-            "Contact field keys should contain at least one letter."
+            "Contact field key without letter characters detected",
+            {"key": key, "name": field_name}
         )
 
-    return field_key
+    return key
 
 
 def generate_field_name(field_name):

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,15 +1,35 @@
-import unittest
+from unittest import TestCase
 
 from rpft.rapidpro.models.actions import EnterFlowAction
+from rpft.rapidpro.models.common import generate_field_key
+from rpft.rapidpro.models.exceptions import RapidProActionError
 
 
-class TestActions(unittest.TestCase):
-    def setUp(self) -> None:
-        pass
+class TestActions(TestCase):
 
     def test_enter_flow_node(self):
-        enter_flow_node = EnterFlowAction(flow_name="test_flow", flow_uuid="fake-uuid")
-        render_output = enter_flow_node.render()
-        self.assertEqual(render_output["type"], "enter_flow")
-        self.assertEqual(render_output["flow"]["name"], "test_flow")
-        self.assertEqual(render_output["flow"]["uuid"], "fake-uuid")
+        out = EnterFlowAction(flow_name="test_flow", flow_uuid="fake-uuid").render()
+
+        self.assertEqual(out["type"], "enter_flow")
+        self.assertEqual(out["flow"]["name"], "test_flow")
+        self.assertEqual(out["flow"]["uuid"], "fake-uuid")
+
+
+class TestFieldKeyGenerator(TestCase):
+
+    def test_generate_key_from_field_name(self):
+        self.assertEqual(
+            generate_field_key(" Field Name "),
+            "field_name",
+        )
+
+    def test_generate_keys_up_to_max_length_limit(self):
+        self.assertIsNotNone(generate_field_key("x" * 36))
+
+    def test_fail_if_max_key_length_exceeded(self):
+        with self.assertRaises(RapidProActionError):
+            generate_field_key("z" * 37)
+
+    def test_fail_if_key_does_not_contain_letters(self):
+        with self.assertRaises(RapidProActionError):
+            generate_field_key("123")

--- a/tests/test_import_export.py
+++ b/tests/test_import_export.py
@@ -121,20 +121,26 @@ class TestImportExport(unittest.TestCase):
 
     def test_campaign_events(self):
         self.maxDiff = None
-        filenamesList = self.data_dir.glob("campaigns/event_*.json")
-        for filename in filenamesList:
+
+        for filename in self.data_dir.glob("campaigns/event_*.json"):
             with open(filename, "r") as f:
                 data = json.load(f)
-            event = CampaignEvent.from_dict(data)
-            render_output = event.render()
-            self.assertEqual(render_output, data, msg=filename)
+
+            self.assertEqual(
+                CampaignEvent.from_dict(data).render(),
+                data,
+                msg=filename,
+            )
 
     def test_campaigns(self):
         self.maxDiff = None
-        filenamesList = self.data_dir.glob("campaigns/campaign_*.json")
-        for filename in filenamesList:
+
+        for filename in self.data_dir.glob("campaigns/campaign_*.json"):
             with open(filename, "r") as f:
                 data = json.load(f)
-            campaign = Campaign.from_dict(data)
-            render_output = campaign.render()
-            self.assertEqual(render_output, data, msg=filename)
+
+            self.assertEqual(
+                Campaign.from_dict(data).render(),
+                data,
+                msg=filename,
+            )

--- a/tests/test_surveyparser.py
+++ b/tests/test_surveyparser.py
@@ -70,9 +70,9 @@ class TestSurveyParser(TestTemplate):
         )
         survey_data = csv_join(
             "ID,type,question,variable,completion_variable,expiration.message",
-            "name,text,Enter your name,name,name_complete,",
-            "else,text,Enter something else,else,else_complete,You waited too long",
-            "age,text,Enter your age,,,",
+            "first,text,First question?,first,first_complete,",
+            "second,text,Second question?,second,second_complete,You waited too long",
+            "third,text,Third question?,,,",
         )
 
         output = (
@@ -90,34 +90,34 @@ class TestSurveyParser(TestTemplate):
 
         self.assertFlowMessages(
             output,
-            "survey - Survey Name - question - name",
+            "survey - Survey Name - question - first",
             [
                 ("set_run_result", "dummy"),
-                ("send_msg", "Enter your name"),
-                ("set_contact_field", "name"),
-                ("set_contact_field", "name_complete"),
+                ("send_msg", "First question?"),
+                ("set_contact_field", "first"),
+                ("set_contact_field", "first_complete"),
             ],
-            Context(inputs=["My name"]),
+            Context(inputs=["First answer"]),
         )
 
         self.assertFlowMessages(
             output,
-            "survey - Survey Name - question - age",
+            "survey - Survey Name - question - third",
             [
                 ("set_run_result", "dummy"),
-                ("send_msg", "Enter your age"),
-                ("set_contact_field", "sq_surveyname_age"),
-                ("set_contact_field", "sq_surveyname_age_complete"),
+                ("send_msg", "Third question?"),
+                ("set_contact_field", "sq_surveyname_third"),
+                ("set_contact_field", "sq_surveyname_third_complete"),
             ],
-            Context(inputs=["23"]),
+            Context(inputs=["Third answer"]),
         )
 
         self.assertFlowMessages(
             output,
             "survey - Survey Name",
             [
-                ("enter_flow", "survey - Survey Name - question - name"),
-                ("enter_flow", "survey - Survey Name - question - else"),
+                ("enter_flow", "survey - Survey Name - question - first"),
+                ("enter_flow", "survey - Survey Name - question - second"),
                 ("send_msg", "You waited too long"),
                 ("set_run_result", "expired"),
             ],
@@ -128,9 +128,9 @@ class TestSurveyParser(TestTemplate):
             output,
             "survey - Survey Name",
             [
-                ("enter_flow", "survey - Survey Name - question - name"),
-                ("enter_flow", "survey - Survey Name - question - else"),
-                ("enter_flow", "survey - Survey Name - question - age"),
+                ("enter_flow", "survey - Survey Name - question - first"),
+                ("enter_flow", "survey - Survey Name - question - second"),
+                ("enter_flow", "survey - Survey Name - question - third"),
                 ("set_run_result", "proceed"),
             ],
             Context(inputs=["completed", "completed", "completed"]),
@@ -140,7 +140,7 @@ class TestSurveyParser(TestTemplate):
             output,
             "survey - Survey Name",
             [
-                ("enter_flow", "survey - Survey Name - question - name"),
+                ("enter_flow", "survey - Survey Name - question - first"),
             ],
             Context(inputs=["completed"], variables={"@child.results.stop": "yes"}),
         )


### PR DESCRIPTION
Will stop processing if a reserved contact field key is encountered when creating "set_contact_field" actions.

A clear distinction is made between 'user' and 'system' contact fields. Only user contact field keys are restricted.

Closes #150 