### PR TITLE
Remove BooleanWrapper

### DIFF
--- a/src/rpft/parsers/common/rowparser.py
+++ b/src/rpft/parsers/common/rowparser.py
@@ -309,7 +309,7 @@ class RowParser:
                 # Otherwise leave it as a string
                 value = self.cell_parser.parse(value, context=template_context)
             else:
-                value = self.cell_parser.parse_as_string(
+                value, _ = self.cell_parser.parse_as_string(
                     value, context=template_context
                 )
         self.assign_value(field, key, value, model)

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -11,7 +11,7 @@ class MockCellParser:
         return value
 
     def parse_as_string(self, value, context={}):
-        return value
+        return value, False
 
     def join_from_lists(self, nested_list):
         return nested_list


### PR DESCRIPTION
Returning a value and boolean as a tuple achieves the same result and makes what to expect from the parse_as_string method clearer.