### PR TITLE
Remove shutdown handler

### DIFF
--- a/src/rpft/cli.py
+++ b/src/rpft/cli.py
@@ -4,7 +4,8 @@ import json
 from rpft import converters
 from rpft.logger.logger import initialize_main_logger
 
-LOGGER = initialize_main_logger()
+
+initialize_main_logger()
 
 
 def main():

--- a/src/rpft/converters.py
+++ b/src/rpft/converters.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 import shutil
-import sys
 from pathlib import Path
 
 from rpft.parsers.creation.contentindexparser import ContentIndexParser
@@ -41,7 +40,7 @@ def create_flows(input_files, output_file, sheet_format, data_models=None, tags=
         )
     except Exception as e:
         LOGGER.critical(e.args[0])
-        sys.exit(1)
+        raise
 
     if output_file:
         with open(output_file, "w", encoding="utf8") as export:

--- a/src/rpft/converters.py
+++ b/src/rpft/converters.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import shutil
+import sys
 from pathlib import Path
 
 from rpft.parsers.creation.contentindexparser import ContentIndexParser
@@ -40,7 +41,7 @@ def create_flows(input_files, output_file, sheet_format, data_models=None, tags=
         )
     except Exception as e:
         LOGGER.critical(e.args[0])
-        raise
+        sys.exit(1)
 
     if output_file:
         with open(output_file, "w", encoding="utf8") as export:

--- a/src/rpft/logger/logger.py
+++ b/src/rpft/logger/logger.py
@@ -48,10 +48,17 @@ class ContextFilter(logging.Filter):
 
 
 def initialize_main_logger(file_path="errors.log"):
-    handler = logging.FileHandler(file_path, "w")
-    handler.addFilter(ContextFilter())
+    context_filter = ContextFilter()
+
+    file_handler = logging.FileHandler(file_path, "w")
+    file_handler.addFilter(context_filter)
+
+    console_handler = logging.StreamHandler()
+    console_handler.addFilter(context_filter)
+    console_handler.setLevel(logging.CRITICAL)
+
     logging.basicConfig(
         level=logging.INFO,
         format="%(levelname)s:%(name)s: %(processing_stack)s: %(message)s",
-        handlers=[handler],
+        handlers=[file_handler, console_handler],
     )

--- a/src/rpft/parsers/common/cellparser.py
+++ b/src/rpft/parsers/common/cellparser.py
@@ -1,11 +1,11 @@
+import logging
 import re
 
 from jinja2 import Environment, contextfilter
 from jinja2.nativetypes import NativeEnvironment
 
-from rpft.logger.logger import get_logger
 
-LOGGER = get_logger()
+LOGGER = logging.getLogger(__name__)
 
 
 class CellParserError(Exception):
@@ -106,7 +106,7 @@ class CellParser:
 
             # Ensure this is a single template, not e.g. '{@ x @} {@ y @}'
             if "{@" in stripped[2:]:
-                LOGGER.critical(
+                raise Exception(
                     'Cell may not contain nested "{{@" templates.'
                     f'Cell content: "{stripped}"'
                 )
@@ -114,7 +114,7 @@ class CellParser:
         try:
             return env.from_string(stripped).render(context), is_object
         except Exception as e:
-            LOGGER.critical(
+            raise Exception(
                 f'Error while parsing cell "{stripped}" with context "{context}":'
                 f" {str(e)}"
             )

--- a/src/rpft/parsers/common/sheetparser.py
+++ b/src/rpft/parsers/common/sheetparser.py
@@ -1,12 +1,8 @@
 import copy
-import logging
 
 from rpft.parsers.common.rowdatasheet import RowDataSheet
 from rpft.parsers.common.rowparser import RowParser
 from rpft.logger.logger import logging_context
-
-
-LOGGER = logging.getLogger(__name__)
 
 
 class SheetParser:
@@ -44,7 +40,6 @@ class SheetParser:
             self.input_rows.append((row_dict, row_idx + 2))
         self.iterator = iter(self.input_rows)
         self.context = copy.deepcopy(context)
-        LOGGER.info("Sheet reader created")
 
     def add_to_context(self, key, value):
         self.context[key] = value

--- a/src/rpft/parsers/common/sheetparser.py
+++ b/src/rpft/parsers/common/sheetparser.py
@@ -1,9 +1,12 @@
 import copy
+import logging
+
 from rpft.parsers.common.rowdatasheet import RowDataSheet
 from rpft.parsers.common.rowparser import RowParser
-from rpft.logger.logger import get_logger, logging_context
+from rpft.logger.logger import logging_context
 
-LOGGER = get_logger()
+
+LOGGER = logging.getLogger(__name__)
 
 
 class SheetParser:
@@ -41,6 +44,7 @@ class SheetParser:
             self.input_rows.append((row_dict, row_idx + 2))
         self.iterator = iter(self.input_rows)
         self.context = copy.deepcopy(context)
+        LOGGER.info("Sheet reader created")
 
     def add_to_context(self, key, value):
         self.context[key] = value

--- a/src/rpft/parsers/creation/__init__.py
+++ b/src/rpft/parsers/creation/__init__.py
@@ -1,7 +1,9 @@
-from rpft.logger.logger import get_logger
+import logging
+
 from rpft.parsers.creation.models import TemplateSheet
 
-LOGGER = get_logger()
+
+LOGGER = logging.getLogger(__name__)
 
 
 def map_template_arguments(template: TemplateSheet, args, context, data_sheets) -> dict:
@@ -39,7 +41,7 @@ def map_template_arguments(template: TemplateSheet, args, context, data_sheets) 
         value = arg if arg != "" else arg_def.default_value
 
         if value == "":
-            LOGGER.critical(f'Required template argument "{arg_def.name}" not provided')
+            raise Exception(f'Required template argument "{arg_def.name}" not provided')
 
         value = data_sheets[value].rows if arg_def.type == "sheet" else value
 

--- a/src/rpft/parsers/creation/campaignparser.py
+++ b/src/rpft/parsers/creation/campaignparser.py
@@ -1,7 +1,10 @@
-from rpft.rapidpro.models.campaigns import Campaign, CampaignEvent
-from rpft.logger.logger import get_logger, logging_context
+import logging
 
-LOGGER = get_logger()
+from rpft.rapidpro.models.campaigns import Campaign, CampaignEvent
+from rpft.logger.logger import logging_context
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 class CampaignParser:
@@ -34,5 +37,5 @@ class CampaignParser:
                     )
                     self.campaign.add_event(event)
                 except ValueError as e:
-                    LOGGER.critical(str(e))
+                    raise Exception(str(e))
         return self.campaign

--- a/src/rpft/parsers/creation/contentindexparser.py
+++ b/src/rpft/parsers/creation/contentindexparser.py
@@ -1,8 +1,9 @@
 import importlib
+import logging
 from collections import OrderedDict
 from typing import Dict, List
 
-from rpft.logger.logger import get_logger, logging_context
+from rpft.logger.logger import logging_context
 from rpft.parsers.common.model_inference import model_from_headers
 from rpft.parsers.common.sheetparser import SheetParser
 from rpft.parsers.creation import globalrowmodels
@@ -21,7 +22,8 @@ from rpft.parsers.creation.triggerrowmodel import TriggerRowModel
 from rpft.parsers.sheets import Sheet
 from rpft.rapidpro.models.containers import RapidProContainer
 
-LOGGER = get_logger()
+
+LOGGER = logging.getLogger(__name__)
 
 
 class DataSheet:
@@ -68,7 +70,7 @@ class ContentIndexParser:
         indices = self.reader.get_sheets_by_name("content_index")
 
         if not indices:
-            LOGGER.critical("No content index sheet provided")
+            raise Exception("No content index sheet provided")
 
         for sheet in indices:
             self._process_content_index_table(sheet)
@@ -98,7 +100,7 @@ class ContentIndexParser:
                     "data_sheet",
                     ContentIndexType.SURVEY.value,
                 ]:
-                    LOGGER.critical(
+                    raise Exception(
                         f"For {row.type} rows, exactly one sheet_name has to be"
                         " specified"
                     )
@@ -110,7 +112,7 @@ class ContentIndexParser:
                         self._process_content_index_table(sheet)
                 elif row.type == "data_sheet":
                     if not len(row.sheet_name) >= 1:
-                        LOGGER.critical(
+                        raise Exception(
                             "For data_sheet rows, at least one sheet_name has to be"
                             " specified"
                         )
@@ -224,7 +226,7 @@ class ContentIndexParser:
 
         else:
             if not row.new_name:
-                LOGGER.critical(
+                raise Exception(
                     "If an operation is applied to a data_sheet, a new_name has to be"
                     " provided"
                 )
@@ -240,7 +242,7 @@ class ContentIndexParser:
                     sheet_names[0], row.data_model, row.operation
                 )
             else:
-                LOGGER.critical(f'Unknown operation "{row.operation}"')
+                raise Exception(f'Unknown operation "{row.operation}"')
 
         new_name = row.new_name or sheet_names[0]
 
@@ -267,7 +269,7 @@ class ContentIndexParser:
                 if hasattr(self.user_models_module, data_model_name):
                     user_model = getattr(self.user_models_module, data_model_name)
             if not user_model:
-                LOGGER.critical(
+                raise Exception(
                     f'Undefined data_model_name "{data_model_name}" '
                     f"in {self.user_models_module}."
                 )
@@ -293,7 +295,7 @@ class ContentIndexParser:
                 data_sheet = self._get_data_sheet(sheet_name, data_model_name)
 
                 if user_model and user_model is not data_sheet.row_model:
-                    LOGGER.critical(
+                    raise Exception(
                         "Cannot concatenate data_sheets with different underlying"
                         " models"
                     )
@@ -312,9 +314,9 @@ class ContentIndexParser:
                 if eval(operation.expression, {}, dict(row)) is True:
                     new_row_data[row_id] = row
             except NameError as e:
-                LOGGER.critical(f"Invalid filtering expression: {e}")
+                raise Exception(f"Invalid filtering expression: {e}")
             except SyntaxError as e:
-                LOGGER.critical(
+                raise Exception(
                     f'Invalid filtering expression: "{e.text}". '
                     f"SyntaxError at line {e.lineno} character {e.offset}"
                 )
@@ -333,9 +335,9 @@ class ContentIndexParser:
                 )
             )
         except NameError as e:
-            LOGGER.critical(f"Invalid sorting expression: {e}")
+            raise Exception(f"Invalid sorting expression: {e}")
         except SyntaxError as e:
-            LOGGER.critical(
+            raise Exception(
                 f'Invalid sorting expression: "{e.text}". '
                 f"SyntaxError at line {e.lineno} character {e.offset}"
             )

--- a/src/rpft/parsers/creation/flowparser.py
+++ b/src/rpft/parsers/creation/flowparser.py
@@ -1,7 +1,8 @@
 import copy
+import logging
 from collections import defaultdict
 
-from rpft.logger.logger import get_logger, logging_context
+from rpft.logger.logger import logging_context
 from rpft.parsers.common.cellparser import CellParser
 from rpft.parsers.common.rowparser import RowParser
 from rpft.parsers.common.sheetparser import SheetParser
@@ -38,7 +39,8 @@ from rpft.rapidpro.models.nodes import (
 )
 from rpft.rapidpro.models.routers import SwitchRouter
 
-LOGGER = get_logger()
+
+LOGGER = logging.getLogger(__name__)
 
 
 def string_to_int_or_float(s):
@@ -72,9 +74,9 @@ class NodeGroup:
 
     def add_exit(self, destination_uuid, condition):
         if condition != Condition():
-            LOGGER.critical("Cannot attach conditional edges to a block.")
+            raise Exception("Cannot attach conditional edges to a block.")
         if not self.has_loose_exits():
-            LOGGER.critical("Block has no loose exit to connect to.")
+            raise Exception("Block has no loose exit to connect to.")
         for node_group in self.node_groups:
             if node_group.has_loose_exits():
                 node_group.connect_loose_exits(destination_uuid)
@@ -124,7 +126,7 @@ class NoOpNodeGroup:
                 edge.source_node_group.connect_loose_exits(destination_uuid)
 
     def entry_node(self):
-        LOGGER.critical(
+        raise Exception(
             "NotImplementedError: go_to not implemented to link to no_op row."
         )
 
@@ -134,7 +136,7 @@ class NoOpNodeGroup:
             try:
                 source_node_group.add_exit(self.router_node.uuid, condition)
             except RapidProRouterError as e:
-                LOGGER.critical(str(e))
+                raise Exception(str(e))
 
     def add_exit(self, destination_uuid, condition):
         if not self.router_node:
@@ -144,7 +146,7 @@ class NoOpNodeGroup:
                 return
             else:
                 if not condition.variable:
-                    LOGGER.critical("Condition must have a variable.")
+                    raise Exception("Condition must have a variable.")
                 self.router_node = SwitchRouterNode(condition.variable)
                 self.child_node_ref = None
                 for edge in self.parent_edges:
@@ -215,7 +217,7 @@ class RowNodeGroup:
             try:
                 exit_node.update_default_exit(destination_uuid)
             except ValueError as e:
-                LOGGER.critical(str(e))
+                raise Exception(str(e))
             return
 
         # Completed/Expired edge from start_new_flow
@@ -369,7 +371,7 @@ class FlowParser:
     def parse_as_block(self):
         self._parse_block()
         if not len(self.node_group_stack) == 1:
-            LOGGER.critical("Unexpected end of flow. Did you forget end_for/end_block?")
+            raise Exception("Unexpected end of flow. Did you forget end_for/end_block?")
         return self.current_node_group()
 
     def parse(self, add_to_container=True):
@@ -395,7 +397,7 @@ class FlowParser:
                         iteration_variable = row.loop_variable[0]
                     else:
                         with logging_context(f"row {row_idx}"):
-                            LOGGER.critical("begin_for must have a loop_variable")
+                            raise Exception("begin_for must have a loop_variable")
                     index_variable = None
                     if len(row.loop_variable) >= 2 and row.loop_variable[1]:
                         index_variable = row.loop_variable[1]
@@ -442,12 +444,12 @@ class FlowParser:
             if block_type == "root_block":
                 return True
             else:
-                LOGGER.critical("Sheet has unterminated block.")
+                raise Exception("Sheet has unterminated block.")
         elif row.type in block_end_map:
             if block_end_map[row.type] == block_type:
                 return True
             else:
-                LOGGER.critical(
+                raise Exception(
                     f'Wrong block terminator "{row.type}" found for block of type'
                     f" {block_type}."
                 )
@@ -590,7 +592,7 @@ class FlowParser:
             try:
                 headers = list_of_pairs_to_dict(row.webhook.headers)
             except ValueError as e:
-                LOGGER.critical("webhook.headers: " + str(e))
+                raise Exception("webhook.headers: " + str(e))
             return CallWebhookNode(
                 result_name=row.save_name,
                 url=row.webhook.url,
@@ -604,14 +606,14 @@ class FlowParser:
             try:
                 airtime_amounts = list_of_pairs_to_dict(row.mainarg_dict)
             except ValueError as e:
-                LOGGER.critical("airtime_amounts: " + str(e))
+                raise Exception("airtime_amounts: " + str(e))
 
             try:
                 airtime_amounts = {
                     k: string_to_int_or_float(v) for k, v in airtime_amounts.items()
                 }
             except ValueError:
-                LOGGER.critical("airtime_amounts: Current values must be numerical")
+                raise Exception("airtime_amounts: Current values must be numerical")
 
             return TransferAirtimeNode(
                 result_name=row.save_name,
@@ -667,7 +669,7 @@ class FlowParser:
             return None
         elif edge.from_:
             if edge.from_ not in self.row_id_to_nodegroup:
-                LOGGER.critical(
+                raise Exception(
                     f'Edge from row_id "{edge.from_}" which does not exist.'
                 )
             return self.row_id_to_nodegroup[edge.from_]
@@ -680,7 +682,7 @@ class FlowParser:
             try:
                 from_node_group.add_exit(destination_uuid, edge.condition)
             except RapidProRouterError as e:
-                LOGGER.critical(str(e))
+                raise Exception(str(e))
 
     def _parse_goto_row(self, row):
         # If there is a single destination, connect all edges to that destination.
@@ -692,7 +694,7 @@ class FlowParser:
         )
 
         if not len(row.edges) == len(destination_row_ids):
-            LOGGER.critical(
+            raise Exception(
                 "If a go_to has multiple destinations, the number of destinations has"
                 " to match the number of incoming edges."
             )
@@ -736,7 +738,7 @@ class FlowParser:
         try:
             row_action = self._get_row_action(row)
         except RapidProActionError as e:
-            LOGGER.critical(str(e))
+            raise Exception(str(e))
         node_name = self._get_node_name(row)
         existing_node = self.node_name_to_node_map.get(node_name)
 
@@ -760,12 +762,12 @@ class FlowParser:
                         ]
                     return
                 else:
-                    LOGGER.critical(
+                    raise Exception(
                         f'To merge rows using node name "{node_name}" into a single'
                         f' node, edge must come from a node with name "{node_name}".'
                     )
             else:
-                LOGGER.critical(
+                raise Exception(
                     f'To merge rows using node name "{node_name}" into a single node,'
                     " there must be exactly one unconditional incoming edge."
                 )
@@ -795,7 +797,7 @@ class FlowParser:
         # Caveat/TODO: Need to ensure starting node comes first.
         flow_container = FlowContainer(flow_name=self.flow_name, uuid=self.flow_uuid)
         if not len(self.node_group_stack) == 1:
-            LOGGER.critical("Unexpected end of flow. Did you forget end_for/end_block?")
+            raise Exception("Unexpected end of flow. Did you forget end_for/end_block?")
         self.current_node_group().add_nodes_to_flow(flow_container)
         return flow_container
 
@@ -820,7 +822,7 @@ class FlowParser:
                     definition=self.definition,
                 )
         else:
-            LOGGER.critical(
+            raise Exception(
                 "For insert_as_block, either both data_sheet and data_row_id or neither"
                 " have to be provided."
             )
@@ -900,7 +902,7 @@ class FlowParser:
 
                             flows[flow.name] = flow
                 elif not row.data_sheet and row.data_row_id:
-                    LOGGER.critical(
+                    raise Exception(
                         "For create_flow, if data_row_id is provided, data_sheet must"
                         " also be provided."
                     )

--- a/src/rpft/parsers/creation/surveyparser.py
+++ b/src/rpft/parsers/creation/surveyparser.py
@@ -1,7 +1,8 @@
 import copy
+import logging
 import re
 
-from rpft.logger.logger import get_logger, logging_context
+from rpft.logger.logger import logging_context
 from rpft.parsers.common.rowparser import ParserModel
 from rpft.parsers.creation import map_template_arguments
 from rpft.parsers.creation.models import ChatbotDefinition
@@ -9,7 +10,7 @@ from rpft.parsers.creation.flowparser import FlowParser
 from rpft.rapidpro.models.containers import RapidProContainer
 
 
-LOGGER = get_logger()
+LOGGER = logging.getLogger(__name__)
 
 
 def name_to_id(name):

--- a/src/rpft/parsers/creation/triggerparser.py
+++ b/src/rpft/parsers/creation/triggerparser.py
@@ -1,7 +1,10 @@
-from rpft.logger.logger import get_logger, logging_context
+import logging
+
+from rpft.logger.logger import logging_context
 from rpft.rapidpro.models.triggers import Trigger
 
-LOGGER = get_logger()
+
+LOGGER = logging.getLogger(__name__)
 
 
 class TriggerParser:
@@ -27,5 +30,5 @@ class TriggerParser:
                     )
                     triggers.append(trigger)
                 except ValueError as e:
-                    LOGGER.critical(str(e))
+                    raise Exception(str(e))
         return triggers

--- a/src/rpft/rapidpro/models/common.py
+++ b/src/rpft/rapidpro/models/common.py
@@ -97,13 +97,13 @@ def generate_field_key(field_name):
     if len(key) > FIELD_KEY_MAX_LENGTH:
         raise RapidProActionError(
             "Contact field key length limit exceeded",
-            {"length": len(key), "limit": FIELD_KEY_MAX_LENGTH, "key": key}
+            {"length": len(key), "limit": FIELD_KEY_MAX_LENGTH, "key": key},
         )
 
     if not re.search("[A-Za-z]", key):
         raise RapidProActionError(
             "Contact field key without letter characters detected",
-            {"key": key, "name": field_name}
+            {"key": key, "name": field_name},
         )
 
     return key


### PR DESCRIPTION
Removes the `ShutdownHandler` logging handler in favour of raising and (optionally) catching exceptions. The behaviour of the toolkit should be exactly the same as before - making this change backwards-compatible.

The shutdown handler uses the Python logging framework to control program execution, in particular, halting the program if a critical-level log message is emitted. This is undesirable for the following reasons:

- Surprise factor - this is not a widespread practice, and it is not obvious or expected that logging a critical message should halt the program.
- Testing critical conditions is more difficult because there is no obvious way to test for the presence of a log message, but it is easy to test whether an exception has been raised.
- Clients of the toolkit (e.g. pipeline, CLI) should be free to configure their own logging preferences without (inadvertently) affecting the execution of the toolkit