### PR TITLE
RapidPro: Add support to remove from all groups if left blank

### DIFF
--- a/src/rpft/parsers/creation/flowparser.py
+++ b/src/rpft/parsers/creation/flowparser.py
@@ -514,6 +514,8 @@ class FlowParser:
             if not row.mainarg_groups:
                 LOGGER.warning(f"Removing contact from ALL groups.")
                 return RemoveContactGroupAction(groups=[], all_groups=True)
+            elif row.mainarg_groups[0] == "ALL":
+                return RemoveContactGroupAction(groups=[], all_groups=True)
             else:
                 return RemoveContactGroupAction(
                     groups=[

--- a/src/rpft/parsers/creation/flowparser.py
+++ b/src/rpft/parsers/creation/flowparser.py
@@ -512,6 +512,7 @@ class FlowParser:
             )
         elif row.type == "remove_from_group":
             if not row.mainarg_groups:
+                LOGGER.warning(f"Removing contact from ALL groups.")
                 return RemoveContactGroupAction(groups=[], all_groups=True)
             else:
                 return RemoveContactGroupAction(

--- a/src/rpft/parsers/creation/flowparser.py
+++ b/src/rpft/parsers/creation/flowparser.py
@@ -511,9 +511,14 @@ class FlowParser:
                 scheme=row.urn_scheme or "tel",
             )
         elif row.type == "remove_from_group":
-            return RemoveContactGroupAction(
-                groups=[self._get_or_create_group(row.mainarg_groups[0], row.obj_id)]
-            )
+            if not row.mainarg_groups:
+                return RemoveContactGroupAction(groups=[], all_groups=True)
+            else:
+                return RemoveContactGroupAction(
+                    groups=[
+                        self._get_or_create_group(row.mainarg_groups[0], row.obj_id)
+                    ]
+                )
         elif row.type == "save_flow_result":
             return SetRunResultAction(
                 row.save_name, row.mainarg_value, category=row.result_category
@@ -549,7 +554,7 @@ class FlowParser:
     def _get_row_node(self, row):
         if (
             row.type in ["add_to_group", "remove_from_group", "split_by_group"]
-            and row.obj_id
+            and row.obj_id and row.mainarg_groups
         ):
             self.rapidpro_container.record_group_uuid(row.mainarg_groups[0], row.obj_id)
 

--- a/src/rpft/rapidpro/models/actions.py
+++ b/src/rpft/rapidpro/models/actions.py
@@ -373,17 +373,17 @@ class GenericGroupAction(Action):
             group.assign_uuid(uuid_dict)
 
     def main_value(self):
-        return self.groups[0].name
+        return self.groups[0].name if self.groups else ""
 
     def render(self):
         return NotImplementedError
 
     def get_row_model_fields(self):
         # abstract method
+        obj_id = [group.uuid for group in self.groups][0] if self.groups else ""
         return {
             "mainarg_groups": [group.name for group in self.groups],
-            "obj_id": [group.uuid for group in self.groups][0]
-            or "",  # 0th element as obj_id is not yet a list.
+            "obj_id": obj_id or "",  # 0th element as obj_id is not yet a list.
         }
 
 

--- a/tests/input/no_switch_nodes.csv
+++ b/tests/input/no_switch_nodes.csv
@@ -10,3 +10,4 @@
 9,"set_contact_language",8,,,,,,"eng",,,,,,,,,,,,,,,,,,"711ea340-dc20-4471-a0e4-6af2c4a278b9",,"execute_actions","280;1020"
 10,"set_contact_name",9,,,,,,"John Doe",,,,,,,,,,,,,,,,,,"711ea340-dc20-4471-a0e4-6af2c4a278b9",,"execute_actions","280;1020"
 11,"add_contact_urn",10,,,,,,"@results.internation_phone_number",,,,,,,,,,,,,,,,,,"768afc12-93e8-4cf8-9cdc-c92cce36c365",,,
+12,"remove_from_group",11,,,,,,,,,,,,,,,,,,,,,,,,"12340fc2-f28c-4ad0-8c02-4afd63ad31ab",,,

--- a/tests/input/no_switch_nodes_without_row_ids.csv
+++ b/tests/input/no_switch_nodes_without_row_ids.csv
@@ -10,3 +10,4 @@
 ,"set_contact_language",,,,,,,"eng",,,,,,,,,,,,,,,,,"711ea340-dc20-4471-a0e4-6af2c4a278b9",,"execute_actions","280;1020"
 ,"set_contact_name",,,,,,,"John Doe",,,,,,,,,,,,,,,,,"711ea340-dc20-4471-a0e4-6af2c4a278b9",,"execute_actions","280;1020"
 ,"add_contact_urn",,,,,,,"@results.internation_phone_number",,,,,,,,,,,,,,,,,"768afc12-93e8-4cf8-9cdc-c92cce36c365",,,
+,"remove_from_group",,,,,,,,,,,,,,,,,,,,,,,,"12340fc2-f28c-4ad0-8c02-4afd63ad31ab",,,

--- a/tests/output/all_test_flows.json
+++ b/tests/output/all_test_flows.json
@@ -172,6 +172,23 @@
           "exits": [
             {
               "uuid": "51548997-3f36-487d-9498-b48e33907b49",
+              "destination_uuid": "12340fc2-f28c-4ad0-8c02-4afd63ad31ab"
+            }
+          ]
+        },
+        {
+          "uuid": "12340fc2-f28c-4ad0-8c02-4afd63ad31ab",
+          "actions": [
+            {
+              "type": "remove_contact_groups",
+              "groups": [],
+              "all_groups": true,
+              "uuid": "1234d6d0-02a2-4edf-9025-8e00959e4d05"
+            }
+          ],
+          "exits": [
+            {
+              "uuid": "d9482afc-9802-4c49-87e0-6b6512b19632",
               "destination_uuid": null
             }
           ]

--- a/tests/test_flowparser.py
+++ b/tests/test_flowparser.py
@@ -155,7 +155,7 @@ class TestParsing(TestCase):
         nodes = output["nodes"]
         all_node_uuids = [row.node_uuid for row in self.rows]
         # Rows 0,1,2,3 and rows -3,-2 are actions joined into a single node.
-        expected_node_uuids = all_node_uuids[3:-2] + all_node_uuids[-1:]
+        expected_node_uuids = all_node_uuids[3:-3] + all_node_uuids[-2:]
         self.assertEqual(
             expected_node_uuids,
             [node["uuid"] for node in nodes],
@@ -165,7 +165,7 @@ class TestParsing(TestCase):
         self.assertEqual(output["type"], "messaging")
         self.assertEqual(output["language"], "eng")
 
-        self.assertEqual(len(nodes), 7)
+        self.assertEqual(len(nodes), 8)
 
         node_0 = nodes[0]
         self.assertEqual(len(node_0["actions"]), 4)
@@ -239,7 +239,13 @@ class TestParsing(TestCase):
 
         node_6 = nodes[6]
         self.assertEqual(node_5["exits"][0]["destination_uuid"], node_6["uuid"])
-        self.assertIsNone(node_6["exits"][0]["destination_uuid"])
+
+        node_7 = nodes[7]
+        self.assertEqual(len(node_7["actions"]), 1)
+        self.assertEqual("remove_contact_groups", node_7["actions"][0]["type"])
+        self.assertEqual(len(node_7["actions"][0]["groups"]), 0)
+        self.assertTrue(node_7["actions"][0]["all_groups"])
+        self.assertIsNone(node_7["exits"][0]["destination_uuid"])
 
         # Check UI positions/types of the first two nodes
         render_ui = output["_ui"]["nodes"]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -234,7 +234,9 @@ action_value_fields = {
     "enter_flow": (lambda x: x["flow"]["name"]),
     "open_ticket": (lambda x: x["subject"]),
     "play_audio": (lambda x: x["audio_url"]),
-    "remove_contact_groups": (lambda x: x["groups"][0]["name"]),
+    "remove_contact_groups": (
+        lambda x: x["groups"][0]["name"] if x["groups"] else "ALL"
+    ),
     "say_msg": (lambda x: x["text"]),
     "send_broadcast": (lambda x: x["text"]),
     "send_email": (lambda x: x["subject"]),


### PR DESCRIPTION
If the main argument ("message_text") is left blank in a `remove_from_group` row, the user will be removed from all groups.

fixes #161 