### PR TITLE
Create client for downloading files from Google Drive

### DIFF
--- a/src/rpft/google.py
+++ b/src/rpft/google.py
@@ -1,0 +1,64 @@
+import json
+import os
+
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google.oauth2.service_account import Credentials as ServiceAccountCredentials
+
+
+# If modifying these scopes, delete the file token.json.
+SCOPES = [
+    "https://www.googleapis.com/auth/drive.readonly",
+    "https://www.googleapis.com/auth/spreadsheets.readonly",
+]
+
+
+def get_credentials():
+    sa_creds = os.getenv("CREDENTIALS")
+
+    if sa_creds:
+        return ServiceAccountCredentials.from_service_account_info(
+            json.loads(sa_creds), scopes=SCOPES
+        )
+
+    creds = None
+    token_file_name = "token.json"
+
+    if os.path.exists(token_file_name):
+        creds = Credentials.from_authorized_user_file(
+            token_file_name,
+            scopes=SCOPES,
+        )
+
+    # If there are no (valid) credentials available, let the user log in.
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file("credentials.json", SCOPES)
+            creds = flow.run_local_server(port=0)
+
+        # Save the credentials for the next run
+        with open(token_file_name, "w") as token:
+            token.write(creds.to_json())
+
+    return creds
+
+
+class Drive:
+
+    @classmethod
+    def client(cls):
+        if not getattr(cls, "_client", None):
+            cls._client = build("drive", "v3", credentials=get_credentials())
+
+        return cls._client
+
+    @classmethod
+    def fetch(cls, file_id):
+        meta = cls.client().files().get(fileId=file_id).execute()
+        content = cls.client().files().get_media(fileId=file_id).execute()
+
+        return meta["name"], content

--- a/src/rpft/parsers/sheets.py
+++ b/src/rpft/parsers/sheets.py
@@ -1,15 +1,12 @@
 import json
-import os
 from abc import ABC
 from pathlib import Path
 from typing import List, Mapping
 
 import tablib
-from google.auth.transport.requests import Request
-from google.oauth2.credentials import Credentials
-from google.oauth2.service_account import Credentials as ServiceAccountCredentials
-from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
+
+from rpft.google import get_credentials
 
 
 class SheetReaderError(Exception):
@@ -84,8 +81,6 @@ class XLSXSheetReader(AbstractSheetReader):
 
 
 class GoogleSheetReader(AbstractSheetReader):
-    # If modifying these scopes, delete the file token.json.
-    SCOPES = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
 
     def __init__(self, spreadsheet_id):
         """
@@ -96,7 +91,7 @@ class GoogleSheetReader(AbstractSheetReader):
 
         self.name = spreadsheet_id
 
-        service = build("sheets", "v4", credentials=self.get_credentials())
+        service = build("sheets", "v4", credentials=get_credentials())
         sheet_metadata = (
             service.spreadsheets().get(spreadsheetId=spreadsheet_id).execute()
         )
@@ -142,37 +137,6 @@ class GoogleSheetReader(AbstractSheetReader):
             [cell.replace("\r\n", "\n") for cell in row],
             max_cols,
         )
-
-    def get_credentials(self):
-        sa_creds = os.getenv("CREDENTIALS")
-        if sa_creds:
-            return ServiceAccountCredentials.from_service_account_info(
-                json.loads(sa_creds), scopes=GoogleSheetReader.SCOPES
-            )
-
-        creds = None
-        token_file_name = "token.json"
-
-        if os.path.exists(token_file_name):
-            creds = Credentials.from_authorized_user_file(
-                token_file_name, scopes=GoogleSheetReader.SCOPES
-            )
-
-        # If there are no (valid) credentials available, let the user log in.
-        if not creds or not creds.valid:
-            if creds and creds.expired and creds.refresh_token:
-                creds.refresh(Request())
-            else:
-                flow = InstalledAppFlow.from_client_secrets_file(
-                    "credentials.json", GoogleSheetReader.SCOPES
-                )
-                creds = flow.run_local_server(port=0)
-
-            # Save the credentials for the next run
-            with open(token_file_name, "w") as token:
-                token.write(creds.to_json())
-
-        return creds
 
 
 class CompositeSheetReader:


### PR DESCRIPTION
Allows files to be downloaded via the Google Drive API. In the short-term, this is intended to resolve an [issue with the ParentText Pipeline](https://github.com/IDEMSInternational/parenttext-pipeline/issues/143). Long-term, it is likely to be useful for uploading and downloading spreadsheets that are generated by the universal parser, which is why it is in the toolkit and not the pipeline.