### PR TITLE
RowParser: support dict types; FlowParser: support different flow types

### DIFF
--- a/src/rpft/parsers/creation/contentindexrowmodel.py
+++ b/src/rpft/parsers/creation/contentindexrowmodel.py
@@ -29,6 +29,7 @@ class ContentIndexRowModel(ParserModel):
     data_row_id: str = ""
     template_argument_definitions: List[TemplateArgument] = []  # internal name
     template_arguments: list = []
+    options: dict = {}
     survey_config: SurveyConfig = SurveyConfig()
     operation: Operation = Operation()
     data_model: str = ""

--- a/src/rpft/parsers/creation/flowparser.py
+++ b/src/rpft/parsers/creation/flowparser.py
@@ -319,6 +319,7 @@ class FlowParser:
         context=None,
         sheet_parser=None,
         definition=None,
+        flow_type=None,
     ):
         """
         rapidpro_container: The parent RapidProContainer to contain the flow generated
@@ -336,6 +337,7 @@ class FlowParser:
         self.rapidpro_container = rapidpro_container
         self.flow_name = flow_name
         self.flow_uuid = flow_uuid
+        self.flow_type = flow_type or "messaging"
         self.context = context or {}
         if sheet_parser:
             self.sheet_parser = sheet_parser
@@ -795,7 +797,7 @@ class FlowParser:
         """
 
         # Caveat/TODO: Need to ensure starting node comes first.
-        flow_container = FlowContainer(flow_name=self.flow_name, uuid=self.flow_uuid)
+        flow_container = FlowContainer(flow_name=self.flow_name, uuid=self.flow_uuid, type=self.flow_type)
         if not len(self.node_group_stack) == 1:
             raise Exception("Unexpected end of flow. Did you forget end_for/end_block?")
         self.current_node_group().add_nodes_to_flow(flow_container)
@@ -837,6 +839,7 @@ class FlowParser:
         parse_as_block=False,
         context=None,
         definition=None,
+        flow_type=None,
     ):
         base_name = new_name or sheet_name
         context = copy.copy(context or {})
@@ -866,6 +869,7 @@ class FlowParser:
             template_sheet.table,
             context=context,
             definition=definition,
+            flow_type=flow_type,
         )
 
         if parse_as_block:
@@ -879,6 +883,7 @@ class FlowParser:
 
         for logging_prefix, row in definition.flow_definitions:
             with logging_context(f"{logging_prefix} | {row.sheet_name[0]}"):
+                flow_type = row.options.get("flow_type") or "messaging"
                 if row.data_sheet and not row.data_row_id:
                     data_rows = definition.get_data_sheet_rows(row.data_sheet)
 
@@ -892,6 +897,7 @@ class FlowParser:
                                 rapidpro_container,
                                 row.new_name,
                                 definition=definition,
+                                flow_type=flow_type,
                             )
 
                             if flow.name in flows:
@@ -915,6 +921,7 @@ class FlowParser:
                         rapidpro_container,
                         row.new_name,
                         definition=definition,
+                        flow_type=flow_type,
                     )
 
                     if flow.name in flows:

--- a/tests/test_rowparser.py
+++ b/tests/test_rowparser.py
@@ -151,3 +151,44 @@ class TestRowParserList(TestRowParserListStr):
         self.emptyModel = ListModel(**{"list_field": []})
         self.oneModel = ListModel(**{"list_field": ["1"]})
         self.onetwoModel = ListModel(**{"list_field": ["1", "2"]})
+
+
+class DictModel(ParserModel):
+    dict_field: dict = {}
+
+
+class TestRowParserDict(unittest.TestCase):
+    def setUp(self):
+        self.parser = RowParser(DictModel, MockCellParser())
+
+    def test_convert_empty(self):
+        self.emptyModel = DictModel(**{"dict_field": {}})
+        inputs = [
+            {},
+            {"dict_field": ""},
+            {"dict_field": []},
+        ]
+        for inp in inputs:
+            out = self.parser.parse_row(inp)
+            self.assertEqual(out, self.emptyModel)
+
+    def test_convert_single_element(self):
+        self.oneModel = DictModel(**{"dict_field": {"K" : "V"}})
+        inputs = [
+            {"dict_field": ["K", "V"]},
+            {"dict_field": [["K", "V"]]},
+            {"dict_field.K": "V"},
+        ]
+        for inp in inputs:
+            out = self.parser.parse_row(inp)
+            self.assertEqual(out, self.oneModel)
+
+    def test_convert_two_element(self):
+        self.onetwoModel = DictModel(**{"dict_field": {"K1" : "V1", "K2" : "V2"}})
+        inputs = [
+            {"dict_field": [["K1", "V1"], ["K2", "V2"]]},
+            {"dict_field.K1": "V1", "dict_field.K2": "V2"},
+        ]
+        for inp in inputs:
+            out = self.parser.parse_row(inp)
+            self.assertEqual(out, self.onetwoModel)


### PR DESCRIPTION
RowModels may now have fields of type `dict`; dict keys are assumed to be strings.
Keys can be either part of column headers with the values being the cell content, or the dict content can be in a single cell as a list of key-value pairs, see example below.

Flows support different [FlowTypes](https://pkg.go.dev/github.com/nyaruka/goflow/flows#FlowType). In the content index, the flow type can now be specified via the `options` column/field which is a dictionary. An entry with key `flow_type` will determine the flow type.

Example:

| type | sheet_name | options|
|---|---|---|
|create_flow|my_flow|flow_type;messaging_background|

This is equivalent to

| type | sheet_name | options.flow_type|
|---|---|---|
|create_flow|my_flow|messaging_background|


fixes #117 
fixes #141