### PR TITLE
Deprecate use of typing.List

### DIFF
--- a/src/rpft/parsers/common/rowparser.py
+++ b/src/rpft/parsers/common/rowparser.py
@@ -47,16 +47,15 @@ def get_list_child_model(model):
 
 
 def is_list_type(model):
-    # Determine whether model is a list type,
-    # such as list, List, List[str], ...
-    # issubclass only works for Python <=3.6
-    # model.__dict__.get('__origin__') returns different things in different Python
-    # version.
-    # This function tries to accommodate both 3.6 and 3.8 (at least)
+    """
+    Determine whether model is a list type, such as list, list[str], List, List[str].
+
+    typing.List is deprecated as of Python 3.9
+    """
     return (
         is_basic_list_type(model)
         or model is List
-        or model.__dict__.get("__origin__") in [list, List]
+        or getattr(model, "__origin__", None) is list
     )
 
 
@@ -205,7 +204,7 @@ class RowParser:
             value = list(value)
             if isinstance(value[0], str):
                 assert len(value) == 2
-                field[key] = {value[0] : value[1]}
+                field[key] = {value[0]: value[1]}
             elif isinstance(value[0], list):
                 for entry in value:
                     assert len(entry) == 2
@@ -327,7 +326,11 @@ class RowParser:
         # The model of field[key] is model, and thus value should also be interpreted
         # as being of type model.
         if not value_is_parsed:
-            if is_list_type(model) or is_basic_dict_type(model) or is_parser_model_type(model):
+            if (
+                is_list_type(model)
+                or is_basic_dict_type(model)
+                or is_parser_model_type(model)
+            ):
                 # If the expected type of the value is list/object,
                 # parse the cell content as such.
                 # Otherwise leave it as a string

--- a/src/rpft/parsers/creation/contentindexparser.py
+++ b/src/rpft/parsers/creation/contentindexparser.py
@@ -1,8 +1,6 @@
 import importlib
 import logging
 from collections import OrderedDict
-from typing import Dict, List
-
 from rpft.logger.logger import logging_context
 from rpft.parsers.common.model_inference import model_from_headers
 from rpft.parsers.common.sheetparser import SheetParser
@@ -58,8 +56,8 @@ class ContentIndexParser:
         self.tag_matcher = tag_matcher
         self.template_sheets = {}
         self.data_sheets = {}
-        self.flow_definition_rows: List[ContentIndexRowModel] = []
-        self.campaign_parsers: Dict[str, tuple[str, CampaignParser]] = {}
+        self.flow_definition_rows: list[ContentIndexRowModel] = []
+        self.campaign_parsers: dict[str, tuple[str, CampaignParser]] = {}
         self.surveys = {}
         self.trigger_parsers = OrderedDict()
         self.user_models_module = (

--- a/src/rpft/parsers/creation/contentindexrowmodel.py
+++ b/src/rpft/parsers/creation/contentindexrowmodel.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import List
 
 from rpft.parsers.common.rowparser import ParserModel
 from rpft.parsers.creation.models import SurveyConfig
@@ -24,10 +23,10 @@ class Operation(ParserModel):
 class ContentIndexRowModel(ParserModel):
     type: str = ""
     new_name: str = ""
-    sheet_name: List[str] = []
+    sheet_name: list[str] = []
     data_sheet: str = ""
     data_row_id: str = ""
-    template_argument_definitions: List[TemplateArgument] = []  # internal name
+    template_argument_definitions: list[TemplateArgument] = []  # internal name
     template_arguments: list = []
     options: dict = {}
     survey_config: SurveyConfig = SurveyConfig()
@@ -35,7 +34,7 @@ class ContentIndexRowModel(ParserModel):
     data_model: str = ""
     group: str = ""
     status: str = ""
-    tags: List[str] = []
+    tags: list[str] = []
 
     def field_name_to_header_name(field):
         if field == "template_argument_definitions":

--- a/src/rpft/parsers/creation/flowrowmodel.py
+++ b/src/rpft/parsers/creation/flowrowmodel.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from rpft.parsers.common.rowparser import ParserModel
 from rpft.parsers.creation.models import Condition
 
@@ -43,7 +41,7 @@ def dict_to_list_of_pairs(headers):
 class WhatsAppTemplating(ParserModel):
     name: str = ""
     uuid: str = ""
-    variables: List[str] = []
+    variables: list[str] = []
 
 
 class Edge(ParserModel):
@@ -69,15 +67,15 @@ class Edge(ParserModel):
 class FlowRowModel(ParserModel):
     row_id: str = ""
     type: str
-    edges: List[Edge]
-    loop_variable: List[str] = []
+    edges: list[Edge]
+    loop_variable: list[str] = []
     include_if: bool = True
     mainarg_message_text: str = ""
     mainarg_value: str = ""
-    mainarg_groups: List[str] = []
+    mainarg_groups: list[str] = []
     mainarg_none: str = ""
     mainarg_dict: list = []  # encoded as list of pairs
-    mainarg_destination_row_ids: List[str] = []
+    mainarg_destination_row_ids: list[str] = []
     mainarg_flow_name: str = ""
     mainarg_expression: str = ""
     mainarg_iterlist: list = []
@@ -86,13 +84,13 @@ class FlowRowModel(ParserModel):
     data_sheet: str = ""
     data_row_id: str = ""
     template_arguments: list = []
-    choices: List[str] = []
+    choices: list[str] = []
     save_name: str = ""
     result_category: str = ""
     image: str = ""
     audio: str = ""
     video: str = ""
-    attachments: List[str] = []
+    attachments: list[str] = []
     urn_scheme: str = ""
     obj_name: str = ""
     obj_id: str = ""
@@ -100,14 +98,8 @@ class FlowRowModel(ParserModel):
     node_uuid: str = ""
     no_response: str = ""
     ui_type: str = ""
-    ui_position: List[str] = []
+    ui_position: list[str] = []
 
-    # TODO: Extra validation here, e.g. from must not be empty
-    # type must come from row_type_to_main_arg.keys() (see below)
-    # image/audio/video only makes sense if type == send_message
-    # mainarg_none should be ''
-    # _ui_position should be '' or a list of two ints
-    # ...
     def field_name_to_header_name(field):
         field_map = {
             "node_uuid": "_nodeId",

--- a/src/rpft/parsers/creation/models.py
+++ b/src/rpft/parsers/creation/models.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from rpft.parsers.common.rowparser import ParserModel
 
 
@@ -31,7 +29,7 @@ class ConditionWithMessage(ParserModel):
 
 
 class ConditionsWithMessage(ParserModel):
-    conditions: List[ConditionWithMessage] = []
+    conditions: list[ConditionWithMessage] = []
     general_message: str = ""
 
 
@@ -61,7 +59,7 @@ class Message(ParserModel):
     image: str = ""
     audio: str = ""
     video: str = ""
-    attachments: List[str] = []
+    attachments: list[str] = []
 
 
 class TemplateSheet:
@@ -76,7 +74,7 @@ class ChatbotDefinition:
         self,
         flow_definitions,
         data_sheets,
-        templates: List[TemplateSheet],
+        templates: list[TemplateSheet],
         surveys,
     ):
         self.flow_definitions = flow_definitions
@@ -119,7 +117,7 @@ class MCQChoice(ParserModel):
 
 
 class PostProcessing(ParserModel):
-    assignments: List[Assignment] = []
+    assignments: list[Assignment] = []
     """
     Assignments to perform via save_value rows.
     """
@@ -157,7 +155,7 @@ class SurveyQuestionModel(ParserModel):
     Type of the question.
     """
 
-    messages: List[Message]
+    messages: list[Message]
     """
     Question text.
     """
@@ -175,7 +173,7 @@ class SurveyQuestionModel(ParserModel):
     the question ID as {variable}_complete.
     """
 
-    choices: List[MCQChoice] = []
+    choices: list[MCQChoice] = []
     """
     MCQ specific fields.
     """
@@ -186,7 +184,7 @@ class SurveyQuestionModel(ParserModel):
     configuration is used.
     """
 
-    relevant: List[Condition] = []
+    relevant: list[Condition] = []
     """
     Conditions required to present the question, otherwise skipped.
     """
@@ -223,7 +221,7 @@ class SurveyQuestionModel(ParserModel):
     that is triggered.
     """
 
-    tags: List[str] = []
+    tags: list[str] = []
     """
     Tags allowing to filter questions to appear in a survey.
     """

--- a/src/rpft/parsers/creation/triggerrowmodel.py
+++ b/src/rpft/parsers/creation/triggerrowmodel.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pydantic.v1 import validator
 
 from rpft.parsers.common.rowparser import ParserModel
@@ -7,10 +5,10 @@ from rpft.parsers.common.rowparser import ParserModel
 
 class TriggerRowModel(ParserModel):
     type: str
-    keywords: List[str] = ""
+    keywords: list[str] = ""
     flow: str = ""
-    groups: List[str] = []
-    exclude_groups: List[str] = []
+    groups: list[str] = []
+    exclude_groups: list[str] = []
     channel: str = ""
     match_type: str = ""
 

--- a/src/rpft/parsers/sheets.py
+++ b/src/rpft/parsers/sheets.py
@@ -1,7 +1,7 @@
 import json
 from abc import ABC
+from collections.abc import Mapping
 from pathlib import Path
-from typing import List, Mapping
 
 import tablib
 from googleapiclient.discovery import build
@@ -28,7 +28,7 @@ class AbstractSheetReader(ABC):
     def get_sheet(self, name) -> Sheet:
         return self.sheets.get(name)
 
-    def get_sheets_by_name(self, name) -> List[Sheet]:
+    def get_sheets_by_name(self, name) -> list[Sheet]:
         return [sheet] if (sheet := self.get_sheet(name)) else []
 
 


### PR DESCRIPTION
`typing.List` is deprecated as of Python 3.9 - use `list`, or `Sequence` or `Iterable` from `collections.abc` instead.