### PR TITLE
Handle exceptions that do not have args

### DIFF
--- a/src/rpft/converters.py
+++ b/src/rpft/converters.py
@@ -2,7 +2,6 @@ import json
 import logging
 import os
 import shutil
-import sys
 from pathlib import Path
 
 from rpft.parsers.creation.contentindexparser import ContentIndexParser
@@ -40,8 +39,8 @@ def create_flows(input_files, output_file, sheet_format, data_models=None, tags=
             .render()
         )
     except Exception as e:
-        LOGGER.critical(e.args[0])
-        sys.exit(1)
+        LOGGER.critical(e.args[0] if e.args else e.__class__.__name__)
+        raise
 
     if output_file:
         with open(output_file, "w", encoding="utf8") as export:


### PR DESCRIPTION
`AssertionError`s do not contain `args` with a descriptive message, instead, one must refer to the stack trace for more details.

The toolkit assumes that all exceptions have `args` with at least one item - the message. This change makes the toolkit check for `args` before indexing into it, otherwise the name of the exception is logged. In all cases, the original exception is re-raised, to provide extra information and to exit the process.

For `AssertionError` the console output will be:

```
CRITICAL:rpft.converters: temp/input/flow_definitions/C_swift_surveys.json-content_index | row 4 | swift_prescreen | row 2: AssertionError
Traceback (most recent call last):
...
    assert is_basic_type(model)
           ~~~~~~~~~~~~~^^^^^^^
AssertionError
```

For errors with `args`:

```
CRITICAL:rpft.converters: temp/input/flow_definitions/T_onboarding.json-content_index | row 9: Boom
Traceback (most recent call last):
...
    raise Exception("Boom")
Exception: Boom
```