### PR TITLE
Make logging configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ The expected contents of the input spreadsheets is documented separately:
 
 The toolkit can fetch spreadsheets from Google Sheets. See the [setup instructions] for details.
 
+# Logging
+
+To override the default logging configuration, see [Logging].
+
 # Development
 
 For instructions on how to set up your development environment for developing the toolkit, see the [development] page.
@@ -81,3 +85,4 @@ For instructions on how to set up your development environment for developing th
 [RapidPro sheet specification]: https://docs.google.com/document/d/1m2yrzZS8kRGihUkPW0YjMkT_Fmz_L7Gl53WjD0AJRV0/edit?usp=sharing
 [New features documentation]: https://docs.google.com/document/d/1Onx2RhNoWKW9BQvFrgTc5R5hcwDy1OMsLKnNB7YxQH0/edit?usp=sharing
 [setup instructions]: docs/google.md
+[Logging]: docs/logging.md

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,18 @@
+# Logging
+
+The logging configuration of the toolkit can be overridden via a JSON file called 'logging.json', located in the current working directory. The contents of the JSON file will be converted into a Python dictionary and passed to `logging.config.dictConfig`. See [Dictionary Schema Details] for information about what can be included in the configuration file.
+
+## Export default configuration to JSON
+
+As a starting point, the default configuration should be exported to JSON for modification.
+
+```sh
+python -c 'import json; from rpft.logger import DEFAULT_CONFIG; print(json.dumps(DEFAULT_CONFIG, indent=2))' > logging.json
+```
+
+## Change the log level of the console handler
+
+A common modification, for debugging, might be to increase the verbosity of the logging messages that appear in the console. The key `handlers.console.level` should be changed to `INFO`. To set the level to `DEBUG` requires setting the key `root.level` to `DEBUG` as well.
+
+
+[Dictionary Schema Details]: https://docs.python.org/3/library/logging.config.html#dictionary-schema-details

--- a/src/rpft/cli.py
+++ b/src/rpft/cli.py
@@ -5,10 +5,8 @@ from rpft import converters
 from rpft.logger.logger import initialize_main_logger
 
 
-initialize_main_logger()
-
-
 def main():
+    initialize_main_logger()
     args = create_parser().parse_args()
     args.func(args)
 

--- a/src/rpft/logger/__init__.py
+++ b/src/rpft/logger/__init__.py
@@ -1,0 +1,37 @@
+DEFAULT_CONFIG = {
+    "disable_existing_loggers": False,
+    "filters": {
+        "context": {
+            "()": "rpft.logger.logger.ContextFilter",
+        }
+    },
+    "formatters": {
+        "default": {
+            "format": "%(levelname)s:%(name)s: %(processing_stack)s: %(message)s",
+        },
+    },
+    "handlers": {
+        "file": {
+            "class": "logging.FileHandler",
+            "filename": "errors.log",
+            "filters": ["context"],
+            "formatter": "default",
+            "level": "INFO",
+            "mode": "w",
+        },
+        "console": {
+            "class": "logging.StreamHandler",
+            "filters": ["context"],
+            "formatter": "default",
+            "level": "CRITICAL",
+        },
+    },
+    "root": {
+        "level": "INFO",
+        "handlers": [
+            "file",
+            "console",
+        ],
+    },
+    "version": 1,
+}

--- a/src/rpft/logger/logger.py
+++ b/src/rpft/logger/logger.py
@@ -7,6 +7,9 @@ from pathlib import Path
 from rpft.logger import DEFAULT_CONFIG
 
 
+logger = logging.getLogger(__name__)
+
+
 class LoggingContextHandler:
     def __init__(self):
         self.context_variables = []
@@ -63,3 +66,4 @@ def initialize_main_logger(file_path="errors.log", config_path="logging.json"):
 
     config["handlers"]["file"]["filename"] = file_path
     dictConfig(config)
+    logger.debug(f"Logging configured, config={config}")

--- a/src/rpft/logger/logger.py
+++ b/src/rpft/logger/logger.py
@@ -1,6 +1,8 @@
+import json
 import logging
 from collections import ChainMap
 from logging.config import dictConfig
+from pathlib import Path
 
 from rpft.logger import DEFAULT_CONFIG
 
@@ -50,7 +52,14 @@ class ContextFilter(logging.Filter):
         return True
 
 
-def initialize_main_logger(file_path="errors.log"):
-    config = dict(DEFAULT_CONFIG)
+def initialize_main_logger(file_path="errors.log", config_path="logging.json"):
+    config = None
+
+    if Path(config_path).exists():
+        with open(config_path, "r") as f:
+            config = json.load(f)
+    else:
+        config = dict(DEFAULT_CONFIG)
+
     config["handlers"]["file"]["filename"] = file_path
     dictConfig(config)

--- a/src/rpft/logger/logger.py
+++ b/src/rpft/logger/logger.py
@@ -1,5 +1,8 @@
 import logging
 from collections import ChainMap
+from logging.config import dictConfig
+
+from rpft.logger import DEFAULT_CONFIG
 
 
 class LoggingContextHandler:
@@ -48,17 +51,6 @@ class ContextFilter(logging.Filter):
 
 
 def initialize_main_logger(file_path="errors.log"):
-    context_filter = ContextFilter()
-
-    file_handler = logging.FileHandler(file_path, "w")
-    file_handler.addFilter(context_filter)
-
-    console_handler = logging.StreamHandler()
-    console_handler.addFilter(context_filter)
-    console_handler.setLevel(logging.CRITICAL)
-
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(levelname)s:%(name)s: %(processing_stack)s: %(message)s",
-        handlers=[file_handler, console_handler],
-    )
+    config = dict(DEFAULT_CONFIG)
+    config["handlers"]["file"]["filename"] = file_path
+    dictConfig(config)


### PR DESCRIPTION
Configures logging with `logging.config.dictConfig`. Optionally, reads logging configuration from a file in the current working directory called 'logging.json', otherwise, falls back to default configuration, which is defined as a `dict` in the code.