### PR TITLE
Skip begin_for blocks if the iterable is empty

### DIFF
--- a/src/rpft/parsers/common/sheetparser.py
+++ b/src/rpft/parsers/common/sheetparser.py
@@ -45,7 +45,7 @@ class SheetParser:
         self.context[key] = value
 
     def remove_from_context(self, key):
-        self.context.pop(key)
+        self.context.pop(key, None)
 
     def create_bookmark(self, name):
         self.bookmarks[name] = copy.copy(self.iterator)


### PR DESCRIPTION
A `begin_for` block would always be evaluated, unless an `include_if` is used to skip the block. In cases where the list being iterated over is empty, we would always want to skip the block, otherwise exceptions will be raised. This means that it is not necessary to set `include_if` to check whether the list is empty or not. Effectively, there is an implicit check of whether the list is empty or not that follows the `include_if` check i.e., `include_if and row.mainarg_iterlist`.