### PR TITLE
Handle IndexError when converting flows to sheets

### DIFF
--- a/src/rpft/rapidpro/models/nodes.py
+++ b/src/rpft/rapidpro/models/nodes.py
@@ -370,11 +370,16 @@ class SwitchRouterNode(RouterNode):
         elif self.router.operand == "@contact.groups":
             # TODO: What about multiple groups?
             # TODO: groups in cases should be implemented differently.
+            try:
+                groups = self.router.cases[0].arguments[1]
+            except IndexError:
+                groups = ""
+
             super().initiate_row_models(
                 current_row_id,
                 parent_edge,
                 type="split_by_group",
-                mainarg_groups=[self.router.cases[0].arguments[1]],
+                mainarg_groups=[groups],
                 obj_id=self.router.cases[0].arguments[0]
                 or "",  # obj_id is not yet a list.
             )

--- a/src/rpft/rapidpro/models/routers.py
+++ b/src/rpft/rapidpro/models/routers.py
@@ -339,16 +339,22 @@ class SwitchRouter(BaseRouter):
             for case_ in self.cases:
                 if case_.category_uuid == category.uuid:
                     covered_category_uuids.add(category.uuid)
-                    arg_idx = 1 if self.operand == "@contact.groups" else 0
+
+                    try:
+                        arg = case_.arguments[
+                            1 if self.operand == "@contact.groups" else 0
+                        ]
+                    except IndexError:
+                        arg = None
 
                     if self.operand in ["@contact.groups", "@child.run.status"]:
                         # For groups and expired/complete, var/type/name are implicit
-                        condition = Condition(value=case_.arguments[arg_idx])
+                        condition = Condition(value=arg or "")
                     else:
                         value = (
-                            case_.arguments[arg_idx]
+                            arg
                             if case_.type not in RouterCase.NO_ARGS_TESTS
-                            and case_.arguments[arg_idx] is not None
+                            and arg is not None
                             else ""
                         )
                         condition = Condition(


### PR DESCRIPTION
Catches possible `IndexError` when converting a router with operand '@contact.groups'.

Relates to [issue](https://github.com/ParentingForLifelongHealth/parenttext-malaysia/issues/115) first encountered in ParentText Malaysia.