### PR TITLE
Support for global templating context

### DIFF
--- a/src/rpft/parsers/creation/contentindexparser.py
+++ b/src/rpft/parsers/creation/contentindexparser.py
@@ -66,7 +66,7 @@ class ContentIndexParser:
             if user_data_model_module_name
             else None
         )
-        indices = self.reader.get_sheets_by_name("content_index")
+        indices = self.reader.get_sheets_by_name(ContentIndexType.CONTENT_INDEX.value)
 
         if not indices:
             raise Exception("No content index sheet provided")
@@ -97,7 +97,7 @@ class ContentIndexParser:
                     continue
 
                 if len(row.sheet_name) != 1 and row.type not in [
-                    "data_sheet",
+                    ContentIndexType.DATA_SHEET.value,
                     ContentIndexType.SURVEY.value,
                     ContentIndexType.SURVEY_QUESTION.value,
                 ]:
@@ -106,12 +106,12 @@ class ContentIndexParser:
                         " specified"
                     )
 
-                if row.type == "content_index":
+                if row.type == ContentIndexType.CONTENT_INDEX.value:
                     sheet = self._get_sheet_or_die(row.sheet_name[0])
 
                     with logging_context(f"{sheet.name}"):
                         self._process_content_index_table(sheet)
-                elif row.type == "data_sheet":
+                elif row.type == ContentIndexType.DATA_SHEET.value:
                     if not len(row.sheet_name) >= 1:
                         raise Exception(
                             "For data_sheet rows, at least one sheet_name has to be"
@@ -119,7 +119,7 @@ class ContentIndexParser:
                         )
 
                     self._process_data_sheet(row)
-                elif row.type == "template_definition":
+                elif row.type == ContentIndexType.TEMPLATE.value:
                     if row.new_name:
                         LOGGER.warning(
                             "template_definition does not support 'new_name'; "
@@ -127,9 +127,9 @@ class ContentIndexParser:
                         )
 
                     self._add_template(row, True)
-                elif row.type == "create_flow":
+                elif row.type == ContentIndexType.FLOW.value:
                     self.flow_definition_rows.append((logging_prefix, row))
-                elif row.type == "create_campaign":
+                elif row.type == ContentIndexType.CAMPAIGN.value:
                     campaign_parser = self.create_campaign_parser(row)
                     name = campaign_parser.campaign.name
 
@@ -140,7 +140,7 @@ class ContentIndexParser:
                         )
 
                     self.campaign_parsers[name] = (logging_prefix, campaign_parser)
-                elif row.type == "create_triggers":
+                elif row.type == ContentIndexType.TRIGGERS.value:
                     self.trigger_parsers[row.sheet_name[0]] = (
                         logging_prefix,
                         self.create_trigger_parser(row),
@@ -149,7 +149,7 @@ class ContentIndexParser:
                     self._add_survey(row, logging_prefix)
                 elif row.type == ContentIndexType.SURVEY_QUESTION.value:
                     self._add_survey_question(row, logging_prefix)
-                elif row.type == "ignore_row":
+                elif row.type == ContentIndexType.IGNORE.value:
                     self._process_ignore_row(row.sheet_name[0])
                 else:
                     LOGGER.error(f"invalid type: '{row.type}'")

--- a/src/rpft/parsers/creation/contentindexrowmodel.py
+++ b/src/rpft/parsers/creation/contentindexrowmodel.py
@@ -7,6 +7,13 @@ from rpft.parsers.creation.models import SurveyConfig
 class ContentIndexType(Enum):
     SURVEY = "survey"
     SURVEY_QUESTION = "survey_question"
+    CONTENT_INDEX = "content_index"
+    FLOW = "create_flow"
+    TEMPLATE = "template_definition"
+    CAMPAIGN = "create_campaign"
+    TRIGGERS = "create_triggers"
+    DATA_SHEET = "data_sheet"
+    IGNORE = "ignore_row"
 
 
 class TemplateArgument(ParserModel):
@@ -44,7 +51,7 @@ class ContentIndexRowModel(ParserModel):
             return "config"
 
     def header_name_to_field_name_with_context(header, row):
-        if row["type"] == "template_definition" and header == "template_arguments":
+        if row["type"] == ContentIndexType.TEMPLATE.value and header == "template_arguments":
             return "template_argument_definitions"
         if row["type"] == ContentIndexType.SURVEY.value and header == "config":
             return "survey_config"

--- a/src/rpft/parsers/creation/contentindexrowmodel.py
+++ b/src/rpft/parsers/creation/contentindexrowmodel.py
@@ -14,6 +14,7 @@ class ContentIndexType(Enum):
     TRIGGERS = "create_triggers"
     DATA_SHEET = "data_sheet"
     IGNORE = "ignore_row"
+    GLOBALS = "globals_dict"
 
 
 class TemplateArgument(ParserModel):

--- a/src/rpft/parsers/creation/flowparser.py
+++ b/src/rpft/parsers/creation/flowparser.py
@@ -922,6 +922,7 @@ class FlowParser:
                                 row.template_arguments,
                                 rapidpro_container,
                                 row.new_name,
+                                context=definition.global_context,
                                 definition=definition,
                                 flow_type=flow_type,
                             )
@@ -946,6 +947,7 @@ class FlowParser:
                         row.template_arguments,
                         rapidpro_container,
                         row.new_name,
+                        context=definition.global_context,
                         definition=definition,
                         flow_type=flow_type,
                     )

--- a/src/rpft/parsers/creation/globalrowmodels.py
+++ b/src/rpft/parsers/creation/globalrowmodels.py
@@ -4,3 +4,7 @@ from rpft.parsers.creation.models import SurveyQuestionModel
 
 class SurveyQuestionRowModel(DataRowModel, SurveyQuestionModel):
     pass
+
+
+class IDValueRowModel(DataRowModel):
+    value: str = ""

--- a/src/rpft/parsers/creation/models.py
+++ b/src/rpft/parsers/creation/models.py
@@ -83,12 +83,14 @@ class ChatbotDefinition:
         templates: list[TemplateSheet],
         surveys,
         survey_questions,
+        global_context=None,
     ):
         self.flow_definitions = flow_definitions
         self.data_sheets = data_sheets
         self.templates = templates
         self.surveys = surveys
         self.survey_questions = survey_questions
+        self.global_context = global_context or {}
 
     def get_data_sheet_rows(self, sheet_name):
         return self.data_sheets[sheet_name].rows


### PR DESCRIPTION
The content index supports a new row type `globals_dict`, example:

| type | sheet_name |
| ------------- | ------------- |
| globals_dict  | my_globals |

`my_globals` refers to a sheet with exactly two columns: `ID` and `value`, both being strings. Example:

| ID | value |
| ------------- | ------------- |
| message  | Hello! |

To access globals in a flow or template definition, use the namespace `globals`. You can use `.` or dictionary access for elements. Example:

|row_id|type|from|message_text|
| ---- | ---- | ---- | ---- |
||send_message|start|{{globals.message}}|
||send_message||{{globals['message']}}|


**Considerations**

We have hard-coded `globals` as the namespace. We could also consider using the `sheet_name`/`new_name` as the namespace, if you want to have access to multiple, or simply no namespace (e.g. you could access values directly via `{{message}}`, which might make selective overriding with template arguments easier).

I discourage using spaces in the ID names, but it is possible because you can use dictionary access to get their values.

If multiple `globals_dict`s are specified, they are merged, with the later one's values being taken in case of a conflict. An info-level message is printed to the logger with the overwritten variable names.