### PR TITLE
Depend on compatible releases of tablib version 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "openpyxl",
     "pydantic >= 2",
     "python-benedict",
-    "tablib @ git+https://github.com/istride/tablib@v3.8.0-1",
+    "tablib ~= 3.8",
 ]
 
 [project.urls]


### PR DESCRIPTION
Direct dependencies are not allowed when uploading to PyPI. It will not be possible to read ODS spreadsheets, except if the tablib dependency is replaced with that at https://github.com/istride/tablib@v3.8.0-1.